### PR TITLE
fix: disable browser back

### DIFF
--- a/packages/extension/src/libs/window-promise/handler.ts
+++ b/packages/extension/src/libs/window-promise/handler.ts
@@ -49,6 +49,11 @@ export default (paramCount: number): Promise<WindowPromiseType> => {
     });
   };
   onMounted(() => {
+    history.pushState(null, "", window.location.href);
+    history.back();
+    window.onpopstate = () => history.forward();
+    // prevents browser back button
+
     newWindowOnMessageFromBackground(
       (message): Promise<InternalOnMessageResponse> => {
         if (


### PR DESCRIPTION
This should disable browser back button
needs testing on

- [x] Chrome
- [x] Firefox
- [x] Opera
- [x] Edge