### PR TITLE
[FIX]: Fix error on send tx view while converting balance to number

### DIFF
--- a/packages/extension/src/providers/bitcoin/ui/send-transaction/index.vue
+++ b/packages/extension/src/providers/bitcoin/ui/send-transaction/index.vue
@@ -199,7 +199,7 @@ const nativeBalance = computed(() => {
   );
   if (accountIndex !== -1) {
     const balance = props.accountInfo.activeBalances[accountIndex];
-    if (balance !== undefined) {
+    if (balance !== "~") {
       return toBase(balance, props.network.decimals);
     }
   }

--- a/packages/extension/src/providers/ethereum/ui/send-transaction/index.vue
+++ b/packages/extension/src/providers/ethereum/ui/send-transaction/index.vue
@@ -225,7 +225,7 @@ const nativeBalance = computed(() => {
   if (accountIndex !== -1) {
     const balance = props.accountInfo.activeBalances[accountIndex];
 
-    if (balance !== undefined) {
+    if (balance !== "~") {
       return toBase(balance, props.network.decimals);
     }
   }


### PR DESCRIPTION
## Description
This PR fixes crash on send tx screen. Below is the console output when users visits send screen.
```
units.ts:29 Uncaught (in promise) Error: while converting number to string, invalid number value '~', should be a number matching (^-?[0-9.]+).
    at numberToString (units.ts:29:13)
    at toBase (units.ts:93:15)
    at ReactiveEffect.fn (index.vue?c8e3:110:20)
    at ReactiveEffect.run (reactivity.esm-bundler.js:187:1)
    at get value [as value] (reactivity.esm-bundler.js:1150:1)
    at ReactiveEffect.fn (index.vue?c8e3:157:19)
    at ReactiveEffect.run (reactivity.esm-bundler.js:187:1)
    at get value [as value] (reactivity.esm-bundler.js:1150:1)
    at unref (reactivity.esm-bundler.js:1056:1)
    at Object.get (reactivity.esm-bundler.js:1059:1)
```

### Snapshot
<img width="1512" alt="Screenshot 2023-01-24 at 7 59 39 AM" src="https://user-images.githubusercontent.com/104683677/214302122-d2bca84d-380d-4744-92e6-a0864ef21290.png">


### Steps to test
- Select ethereum or bitcoin based chain
- Try visiting send screen 
- Open the console
- See the error as attached above

Because `~` symbol is used as default balance value. `balance !== "~"` checks are used everywhere in code so just replicating the check on send screen to fix the error. 