### PR TITLE
devop: add rootstock dapps

### DIFF
--- a/packages/extension/src/libs/dapp-list/index.ts
+++ b/packages/extension/src/libs/dapp-list/index.ts
@@ -45,6 +45,8 @@ const lists: Partial<Record<NetworkNames, string>> = {
     "https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/dapps/zksyncgoerli.json",
   [NetworkNames.ZkSync]:
     "https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/dapps/zksync.json",
+  [NetworkNames.Rootstock]:
+    "https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/dapps/rootstock.json",
 };
 
 export default lists;


### PR DESCRIPTION
### Description
This PR adds `rootstock` dapps link for featured tab for rootstock network. 

###  How it looks: Demo

https://user-images.githubusercontent.com/104683677/214556665-bf94bd42-d33c-42d3-a1b6-0851f92607a9.mov

