### PR TITLE
Add `rootstock` trezor config

### DIFF
--- a/packages/hw-wallets/src/configs.ts
+++ b/packages/hw-wallets/src/configs.ts
@@ -55,6 +55,11 @@ const bip44Paths = {
     basePath: "m/44'/60'/0'/0",
     label: "Ethereum",
   },
+  rootstock: {
+    path: "m/44'/137'/0'/0/{index}",
+    basePath: "m/44'/137'/0'/0",
+    label: "Rootstock",
+  },
   rootstockLedger: {
     path: "m/44'/137'/0'/{index}",
     basePath: "m/44'/137'/0'/0",

--- a/packages/hw-wallets/src/trezor/configs.ts
+++ b/packages/hw-wallets/src/trezor/configs.ts
@@ -7,5 +7,6 @@ const supportedPaths = {
   [NetworkNames.EthereumClassic]: [bip44Paths.ethereumClassic],
   [NetworkNames.Ropsten]: [bip44Paths.ethereumTestnet],
   [NetworkNames.Goerli]: [bip44Paths.ethereumTestnet],
+  [NetworkNames.Rootstock]: [bip44Paths.rootstock],
 };
 export { supportedPaths };

--- a/packages/hw-wallets/src/trezor/index.ts
+++ b/packages/hw-wallets/src/trezor/index.ts
@@ -113,7 +113,7 @@ class TrezorEthereum implements HWWalletProvider {
       }).then((result) => {
         if (!result.success)
           throw new Error((result.payload as any).error as string);
-        const rv = BigInt(result.payload.v.replace("0x", ""));
+        const rv = BigInt(parseInt(result.payload.v, 16));
         const cv = tx.common.chainId() * 2n + 35n;
         return toRpcSig(
           bigIntToHex(rv - cv),


### PR DESCRIPTION
## Description
- This PR adds trezor configuration for the `rootstock` network. 
- This PR also fixes a bug while signing the transactions using trezor by replacing this line
```
 const rv = BigInt(result.payload.v.replace("0x", "")); // This line gives error: Uncaught SyntaxError: Cannot convert 5f to a BigInt
 Reason: Consider v = '0x5f'. The replace is removing 0x and then BigInt does not understand 5f as a hex value because 0x prefix is missing.
 
 Fixed it by using parseInt function.
 const rv = BigInt(parseInt(result.payload.v, 16));
```

## Testing:
- After applying these changes this PR is tested with both ethereum and rootstock networks using trezor
- Works fine with both networks 
