### PR TITLE
[HOT FIX] `Rootstock` ledger derivation path fix

### DIFF
--- a/packages/hw-wallets/src/configs.ts
+++ b/packages/hw-wallets/src/configs.ts
@@ -60,11 +60,6 @@ const bip44Paths = {
     basePath: "m/44'/137'/0'/0",
     label: "Rootstock",
   },
-  rootstockLedger: {
-    path: "m/44'/137'/0'/{index}",
-    basePath: "m/44'/137'/0'/0",
-    label: "Rootstock",
-  },
   ethereumClassic: {
     path: "m/44'/61'/0'/0/{index}",
     basePath: "m/44'/61'/0'/0",

--- a/packages/hw-wallets/src/ledger/ethereum/configs.ts
+++ b/packages/hw-wallets/src/ledger/ethereum/configs.ts
@@ -10,7 +10,7 @@ const supportedPaths = {
     bip44Paths.ethereumLedger,
     bip44Paths.ethereumLedgerLive,
   ],
-  [NetworkNames.Rootstock]: [bip44Paths.rootstockLedger],
+  [NetworkNames.Rootstock]: [bip44Paths.rootstock],
   [NetworkNames.EthereumClassic]: [
     bip44Paths.ethereumClassicLedger,
     bip44Paths.ethereumClassicLedgerLive,


### PR DESCRIPTION
## Description
While sending tx signed by ledger on `rootstock` network, tx rejected with error `ERROR Error: Returned error: the sender account doesn't exist` due to malformed dpath in config.
```
ERROR Error: Returned error: the sender account doesn't exist
```
This PR fixes rootstock dpath in config so that ledger could sign tx accurately. 

![Screenshot 2023-04-10 at 13 43 38](https://user-images.githubusercontent.com/104683677/232078903-a91214a6-19d4-4d9d-b041-aa3bfd00b162.png)

## Testing
Tested this PR on rootstock `mainnet` by sending transactions. Fix worked find. 👍

#### Would be great if this PR could be considered and released on priority so that users could be unblocked to use ledger on rootstock network 🙏

