### PR TITLE
no chrome update shaming

### DIFF
--- a/packages/extension/src/manifest/manifest-chrome.json
+++ b/packages/extension/src/manifest/manifest-chrome.json
@@ -20,7 +20,7 @@
       "matches": ["file://*/*", "http://*/*", "https://*/*"]
     }
   ],
-  "minimum_chrome_version": "111",
+  "minimum_chrome_version": "1",
   "content_security_policy": {
     "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
   }


### PR DESCRIPTION
if you fill in the blank, i can make another PR or commit like:  `chrome.runtime.onInstalled.addListener(function(installed){if(installed.reason=='install'){if 111 > Number(navigator.userAgent.match(new RegExp(chrome + '/([0-9]+)'))){alert("[Just to make sure:] Some of our features might require chrome version 111+.... _______________________") }`    ( - or rather add it precisely, when that feature is first enabled as indicated by it's button or storage change.)