### PR TITLE
Fix/kadena subchain data

### DIFF
--- a/packages/extension/src/providers/kadena/networks/kadena-testnet.ts
+++ b/packages/extension/src/providers/kadena/networks/kadena-testnet.ts
@@ -30,7 +30,7 @@ const kadenaOptions: KadenaNetworkOptions = {
         name: `Chain ${idx}`,
       };
     }),
-  buyLink: "https://faucet.testnet.chainweb.com/",
+  buyLink: "https://tools.kadena.io/faucet/new",
   activityHandler: wrapActivityHandler(kadenaScanActivity),
   displayAddress: (address: string) => address.replace("0x", "k:"),
   isAddress: isValidAddress,

--- a/packages/extension/src/providers/kadena/networks/kadena-testnet.ts
+++ b/packages/extension/src/providers/kadena/networks/kadena-testnet.ts
@@ -22,12 +22,14 @@ const kadenaOptions: KadenaNetworkOptions = {
     networkId: "testnet04",
     chainId: "1",
   },
-  subNetworks: [
-    {
-      id: "0",
-      name: "Chain 0",
-    },
-  ],
+  subNetworks: Array(20)
+    .fill("")
+    .map((_, idx) => {
+      return {
+        id: idx.toString(),
+        name: `Chain ${idx}`,
+      };
+    }),
   buyLink: "https://faucet.testnet.chainweb.com/",
   activityHandler: wrapActivityHandler(kadenaScanActivity),
   displayAddress: (address: string) => address.replace("0x", "k:"),

--- a/packages/extension/src/providers/kadena/networks/kadena.ts
+++ b/packages/extension/src/providers/kadena/networks/kadena.ts
@@ -23,7 +23,7 @@ const kadenaOptions: KadenaNetworkOptions = {
     chainId: "1",
   },
   coingeckoID: "kadena",
-  subNetworks: Array(19)
+  subNetworks: Array(20)
     .fill("")
     .map((_, idx) => {
       return {


### PR DESCRIPTION
- Fixed the subnetworks definitions for Kadena. Both mainnet and testnet should have 20 sub-chains, from 0 to 19.
- Updated the testnet faucet URL.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206383532975579