### PR TITLE
feat: add kadena chain label in activity

### DIFF
--- a/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
+++ b/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
@@ -39,8 +39,8 @@
             />
             <span v-else-if="activity.timestamp !== 0">{{ date }}</span>
             <span
-              class="network-activity__transaction-info-chainid"
               v-if="chainId !== undefined"
+              class="network-activity__transaction-info-chainid"
               >{{ activity.isIncoming ? "on" : "from" }} chain
               {{ chainId }}</span
             >

--- a/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
+++ b/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
@@ -41,7 +41,8 @@
             <span
               class="network-activity__transaction-info-chainid"
               v-if="chainId !== undefined"
-              >on chain {{ chainId }}</span
+              >{{ activity.isIncoming ? "on" : "from" }} chain
+              {{ chainId }}</span
             >
           </p>
         </div>

--- a/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
+++ b/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
@@ -39,10 +39,10 @@
             />
             <span v-else-if="activity.timestamp !== 0">{{ date }}</span>
             <span
-              v-if="chainId !== undefined"
+              v-if="network.subNetworks && activity.chainId !== undefined"
               class="network-activity__transaction-info-chainid"
               >{{ activity.isIncoming ? "on" : "from" }} chain
-              {{ chainId }}</span
+              {{ activity.chainId }}</span
             >
           </p>
         </div>
@@ -120,7 +120,6 @@ import { BaseNetwork } from "@/types/base-network";
 import { fromBase } from "@enkryptcom/utils";
 import BigNumber from "bignumber.js";
 import { imageLoadError } from "@/ui/action/utils/misc";
-import { NetworkNames } from "@enkryptcom/types";
 const props = defineProps({
   activity: {
     type: Object as PropType<Activity>,
@@ -134,7 +133,6 @@ const props = defineProps({
 
 const status = ref("~");
 const date = ref("~");
-const chainId = ref("~");
 
 const transactionURL = computed(() => {
   return props.network.blockExplorerTX.replace(
@@ -149,11 +147,6 @@ const getFiatValue = computed(() => {
 });
 onMounted(() => {
   date.value = moment(props.activity.timestamp).fromNow();
-  chainId.value =
-    props.activity.network === NetworkNames.Kadena ||
-    props.activity.network === NetworkNames.KadenaTestnet
-      ? props.activity.chainId
-      : undefined;
   if (
     props.activity.status === ActivityStatus.success &&
     props.activity.isIncoming

--- a/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
+++ b/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
@@ -38,6 +38,11 @@
               :date="activity.timestamp"
             />
             <span v-else-if="activity.timestamp !== 0">{{ date }}</span>
+            <span
+              class="network-activity__transaction-info-chainid"
+              v-if="chainId !== undefined"
+              >on chain {{ chainId }}</span
+            >
           </p>
         </div>
       </div>
@@ -114,6 +119,7 @@ import { BaseNetwork } from "@/types/base-network";
 import { fromBase } from "@enkryptcom/utils";
 import BigNumber from "bignumber.js";
 import { imageLoadError } from "@/ui/action/utils/misc";
+import { NetworkNames } from "@enkryptcom/types";
 const props = defineProps({
   activity: {
     type: Object as PropType<Activity>,
@@ -127,6 +133,7 @@ const props = defineProps({
 
 const status = ref("~");
 const date = ref("~");
+const chainId = ref("~");
 
 const transactionURL = computed(() => {
   return props.network.blockExplorerTX.replace(
@@ -141,6 +148,11 @@ const getFiatValue = computed(() => {
 });
 onMounted(() => {
   date.value = moment(props.activity.timestamp).fromNow();
+  chainId.value =
+    props.activity.network === NetworkNames.Kadena ||
+    props.activity.network === NetworkNames.KadenaTestnet
+      ? props.activity.chainId
+      : undefined;
   if (
     props.activity.status === ActivityStatus.success &&
     props.activity.isIncoming
@@ -242,6 +254,10 @@ onMounted(() => {
 
       &-status {
         margin-right: 4px;
+      }
+
+      &-chainid {
+        margin-left: 4px;
       }
     }
 

--- a/packages/extension/src/ui/action/views/network-activity/index.vue
+++ b/packages/extension/src/ui/action/views/network-activity/index.vue
@@ -83,10 +83,6 @@ const props = defineProps({
     type: Object as PropType<BaseNetwork>,
     default: () => ({}),
   },
-  subnetwork: {
-    type: String,
-    default: "",
-  },
   accountInfo: {
     type: Object as PropType<AccountsHeaderData>,
     default: () => ({}),

--- a/packages/extension/src/ui/action/views/network-activity/index.vue
+++ b/packages/extension/src/ui/action/views/network-activity/index.vue
@@ -83,6 +83,10 @@ const props = defineProps({
     type: Object as PropType<BaseNetwork>,
     default: () => ({}),
   },
+  subnetwork: {
+    type: String,
+    default: "",
+  },
   accountInfo: {
     type: Object as PropType<AccountsHeaderData>,
     default: () => ({}),


### PR DESCRIPTION
This PR adds a suffixed label in the activities timestamp field which specifies which chain the transaction took place on.

It will only display on the two kadena networks (mainnet, testnet)

Visual:

![1706632225](https://github.com/enkryptcom/enKrypt/assets/115649719/2b70ce1e-6e74-464e-a22e-3417bbab2712)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206465805564930