### PR TITLE
fix: kadena: Activity: missing sender/receiver for cross chain transfers

### DIFF
--- a/packages/extension/src/providers/kadena/libs/activity-handlers/providers/kadena/index.ts
+++ b/packages/extension/src/providers/kadena/libs/activity-handlers/providers/kadena/index.ts
@@ -74,17 +74,17 @@ export default async (
     // note: intentionally not using fromAccount === some-value
     // I want to match both null and "" in fromAccount/toAccount
     // actual values will be a (truthy) string
-    if (!activity.fromAccount && activity.crossChainAccount) {
-      activity.fromAccount = activity.crossChainAccount;
+    let { fromAccount, toAccount } = activity;
+    if (!fromAccount && activity.crossChainAccount) {
+      fromAccount = activity.crossChainAccount;
     }
-    if (!activity.toAccount && activity.crossChainAccount) {
-      activity.toAccount = activity.crossChainAccount;
+    if (!toAccount && activity.crossChainAccount) {
+      toAccount = activity.crossChainAccount;
     }
-    const { fromAccount, toAccount, crossChainAccount } = activity;
     return {
       nonce: i.toString(),
-      from: activity.fromAccount,
-      to: activity.toAccount,
+      from: fromAccount,
+      to: toAccount,
       isIncoming: activity.fromAccount !== address,
       network: network.name,
       rawInfo: activity,

--- a/packages/extension/src/types/activity.ts
+++ b/packages/extension/src/types/activity.ts
@@ -85,6 +85,7 @@ interface Activity {
   from: string;
   to: string;
   chainId?: string;
+  crossChainId?: number;
   value: string;
   timestamp: number;
   nonce?: string;

--- a/packages/extension/src/types/activity.ts
+++ b/packages/extension/src/types/activity.ts
@@ -65,6 +65,21 @@ interface SubstrateRawInfo {
 
 type KadenaRawInfo = ICommandResult;
 
+interface KadenaDBInfo {
+  amount: string;
+  blockHash: string;
+  blockTime: string;
+  chain: number;
+  crossChainAccount: string | null;
+  crossChainId: number | null;
+  fromAccount: string;
+  height: number;
+  idx: number;
+  requestKey: string;
+  toAccount: string;
+  token: string;
+}
+
 enum ActivityStatus {
   pending = "pending",
   success = "success",
@@ -100,7 +115,7 @@ interface Activity {
     | SubscanExtrinsicInfo
     | BTCRawInfo
     | SwapRawInfo
-    | KadenaRawInfo;
+    | KadenaDBInfo;
 }
 
 export {

--- a/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
+++ b/packages/extension/src/ui/action/views/network-activity/components/network-activity-transaction.vue
@@ -26,6 +26,12 @@
                 6
               )
             }}
+            <span v-if="Number.isFinite(activity.crossChainId)">
+              <sup
+                class="network-activity__transaction-info-crosschain-superscript"
+                >⛓️{{ activity.crossChainId }}</sup
+              >
+            </span>
           </h4>
           <p>
             <span
@@ -238,6 +244,10 @@ onMounted(() => {
             color: @error;
           }
         }
+      }
+
+      &-crosschain-superscript {
+        color: @secondaryLabel;
       }
 
       &-status {


### PR DESCRIPTION
This PR fixes an issue with the Activity view of Kadena accounts that have sent of received (chainweb) cross-chain transfers

- The counterparty address was showed as empty. It is now fixed to display the appropriate address
- The cross-chain ID is also displayed in a superscripted "badge"

Before:
![1706633235](https://github.com/enkryptcom/enKrypt/assets/115649719/d2febb42-c433-474f-9e3d-aab86a6a48f6)

After:

![1706633563](https://github.com/enkryptcom/enKrypt/assets/115649719/45ff6f05-1e7a-4d69-a43c-8d44a17eec78)