### PR TITLE
Remove minheight= optimization when querying Kadena activities DB. 

### DIFF
--- a/packages/extension/src/providers/kadena/libs/activity-handlers/providers/kadena/index.ts
+++ b/packages/extension/src/providers/kadena/libs/activity-handlers/providers/kadena/index.ts
@@ -37,12 +37,14 @@ export default async (
     network: network.name,
   };
   const allActivities = await activityState.getAllActivities(options);
-  const lastActivity = allActivities[allActivities.length - 1] as any;
+  // disabling this as there is a bug removing activities
+  // querying from height=zero should remedy it temporarily
+  // const lastActivity = allActivities[allActivities.length - 1] as any;
   const activities = await getAddressActivity(
     address,
     enpoint,
     ttl,
-    lastActivity?.rawInfo?.height ?? 0
+    0 // lastActivity?.rawInfo?.height ?? 0
   );
 
   let price = "0";


### PR DESCRIPTION
We spotted a bug in the pre-release testing where some activities disappear from the list (strangely, even from the middle of the list, not just the edges)  

This PR removes the incremental fetching (minheight= tracking) as a temporary remedy for the bug until it can be fixed properly. 