### PR TITLE
Fix SimpleHash NFT types

### DIFF
--- a/packages/extension/src/libs/nft-handlers/types/simplehash.ts
+++ b/packages/extension/src/libs/nft-handlers/types/simplehash.ts
@@ -17,8 +17,8 @@ export interface SHNFTType {
   };
   external_url: string;
   collection: {
-    name: string;
-    description: string;
+    name: null | string;
+    description: null | string;
     image_url: string;
     external_url: string;
     collection_id: string;

--- a/packages/extension/src/types/nft.ts
+++ b/packages/extension/src/types/nft.ts
@@ -13,9 +13,9 @@ export interface NFTItem {
   type: NFTType;
 }
 export interface NFTCollection {
-  name: string;
+  name: null | string;
   image: string;
-  description: string;
+  description: null | string;
   items: NFTItem[];
   contract: string;
 }

--- a/packages/extension/src/ui/action/views/network-nfts/components/network-nfts-category.vue
+++ b/packages/extension/src/ui/action/views/network-nfts/components/network-nfts-category.vue
@@ -3,9 +3,9 @@
     <div class="network-nfts__category-head">
       <p>
         {{
-          collection.name.length > 25
+          collection.name?.length > 25
             ? $filters.replaceWithEllipsis(collection.name, 25, 4)
-            : collection.name
+            : collection.name || "UNKNOWN"
         }}
       </p>
       <a


### PR DESCRIPTION
This came up when adding Proof of Play Apex network. Simplehash returns null for some NFT collections names and descriptions which causes the NFT list to break.