### PR TITLE
Support for Rango and (almost) Changelly on Solana

### DIFF
--- a/packages/extension/src/libs/keyring/public-keyring.ts
+++ b/packages/extension/src/libs/keyring/public-keyring.ts
@@ -77,6 +77,26 @@ class PublicKeyRing {
         walletType: WalletType.mnemonic,
         isHardware: false,
       };
+      allKeys["77hREDDaAiimedtD9bR1JDMgYLW3AA5yPvD91pvrueRp"] = {
+        address: "77hREDDaAiimedtD9bR1JDMgYLW3AA5yPvD91pvrueRp",
+        basePath: "m/44'/501'/0'/1",
+        name: "fake sol acc 1",
+        pathIndex: 0,
+        publicKey: "0x0",
+        signerType: SignerType.ed25519sol,
+        walletType: WalletType.mnemonic,
+        isHardware: false,
+      };
+      allKeys["tQvduDby4rvC6VU4rSirhVWuRYxbJz3rvUrVMkUWsZP"] = {
+        address: "tQvduDby4rvC6VU4rSirhVWuRYxbJz3rvUrVMkUWsZP",
+        basePath: "m/44'/501'/0'/1",
+        name: "fake sol acc 2",
+        pathIndex: 0,
+        publicKey: "0x0",
+        signerType: SignerType.ed25519sol,
+        walletType: WalletType.mnemonic,
+        isHardware: false,
+      };
     }
     return allKeys;
   }

--- a/packages/extension/src/ui/action/views/swap/libs/solana-gasvals.ts
+++ b/packages/extension/src/ui/action/views/swap/libs/solana-gasvals.ts
@@ -2,7 +2,12 @@ import { GasFeeType, GasPriceTypes } from "@/providers/common/types";
 import SolanaAPI from "@/providers/solana/libs/api";
 import { SolanaNetwork } from "@/providers/solana/types/sol-network";
 import { fromBase } from "@enkryptcom/utils";
-import { VersionedTransaction } from "@solana/web3.js";
+import {
+  VersionedTransaction as SolanaVersionedTransaction,
+  Transaction as SolanaLegacyTransaction,
+  VersionedMessage,
+  Message,
+} from "@solana/web3.js";
 import BigNumber from "bignumber.js";
 import { toBN } from "web3-utils";
 
@@ -11,7 +16,7 @@ import { toBN } from "web3-utils";
  * (not nice but convenient)
  */
 export const getSolanaTransactionFees = async (
-  txs: VersionedTransaction[],
+  txs: (SolanaVersionedTransaction | SolanaLegacyTransaction)[],
   network: SolanaNetwork,
   price: number,
   additionalFee: ReturnType<typeof toBN>
@@ -21,8 +26,12 @@ export const getSolanaTransactionFees = async (
   let latestBlockHash = await conn.getLatestBlockhash();
   for (let i = 0, len = txs.length; i < len; i++) {
     const tx = txs[i];
+
     // Use the latest block hash in-case it's fallen too far behind
-    tx.message.recentBlockhash = latestBlockHash.blockhash;
+    // (can't change block hash if it's already signed)
+    if (!tx.signatures.length) {
+      updateBlockHash(tx, latestBlockHash.blockhash);
+    }
 
     // Not sure why but getFeeForMessage sometimes returns null, so we will retry
     // with small backoff in-case it helps
@@ -36,27 +45,34 @@ export const getSolanaTransactionFees = async (
         throw new Error(
           `Failed to get fee for Solana VersionedTransaction ${i + 1}` +
             ` after ${backoff.length} attempts.` +
-            ` Transaction block hash ${tx.message.recentBlockhash} possibly expired.`
+            ` Transaction block hash` +
+            `${getRecentBlockHash(tx)} possibly expired.`
         );
       }
       if (backoff[attempt] > 0) {
         // wait before retrying
-        await new Promise((res) => {
-          return setTimeout(res, backoff[attempt]);
-        });
+        await new Promise((res) => setTimeout(res, backoff[attempt]));
       }
       // Update the block hash in-case it caused 0 fees to be returned
       if (attempt > 0) {
-        latestBlockHash = await conn.getLatestBlockhash();
-        tx.message.recentBlockhash = latestBlockHash.blockhash;
+        if (!tx.signatures.length) {
+          console.warn(
+            `Cannot update block hash for signed transaction` +
+              ` ${i + 1}, retrying getFeeForMessage using the same` +
+              ` block hash ${getRecentBlockHash(tx)}`
+          );
+        } else {
+          latestBlockHash = await conn.getLatestBlockhash();
+          updateBlockHash(tx, latestBlockHash.blockhash);
+        }
       }
 
       /** Base fee + priority fee (Don't know why this returns null sometimes) */
-      const feeResult = await conn.getFeeForMessage(tx.message);
+      const feeResult = await conn.getFeeForMessage(getMessage(tx));
       if (feeResult.value == null) {
         console.warn(
-          `Failed to get fee for Solana VersionedTransaction` +
-            ` ${i + 1}. Transaction block hash ${tx.message.recentBlockhash}` +
+          `Failed to get fee for Solana VersionedTransaction ${i + 1}.` +
+            ` Transaction block hash ${getRecentBlockHash(tx)}` +
             ` possibly expired. Attempt ${attempt + 1}/${backoff.length}.`
         );
       } else {
@@ -74,7 +90,6 @@ export const getSolanaTransactionFees = async (
   // Convert from lamports to SOL
   const feesumsol = fromBase(feesumlamp.toString(), network.decimals);
 
-  // TODO: give different fees for different priority levels
   return {
     [GasPriceTypes.REGULAR]: {
       nativeValue: feesumsol,
@@ -84,3 +99,47 @@ export const getSolanaTransactionFees = async (
     },
   };
 };
+
+function getRecentBlockHash(
+  tx: SolanaVersionedTransaction | SolanaLegacyTransaction
+): string {
+  return getMessage(tx).recentBlockhash;
+}
+
+function updateBlockHash(
+  tx: SolanaVersionedTransaction | SolanaLegacyTransaction,
+  recentBlockHash: string
+): void {
+  switch ((tx as SolanaVersionedTransaction).version) {
+    case 0:
+    case "legacy":
+      (tx as SolanaVersionedTransaction).message.recentBlockhash =
+        recentBlockHash;
+      break;
+    case undefined:
+      (tx as SolanaLegacyTransaction).recentBlockhash = recentBlockHash;
+      break;
+    default:
+      throw new Error(
+        `Cannot set block hash for Solana transaction: unexpected Solana transaction` +
+          ` type ${Object.getPrototypeOf(tx).constructor.name}`
+      );
+  }
+}
+
+function getMessage(
+  tx: SolanaVersionedTransaction | SolanaLegacyTransaction
+): Message | VersionedMessage {
+  switch ((tx as SolanaVersionedTransaction).version) {
+    case 0:
+    case "legacy":
+      return (tx as SolanaVersionedTransaction).message;
+    case undefined:
+      return (tx as SolanaLegacyTransaction).compileMessage();
+    default:
+      throw new Error(
+        `Cannot get Solana transaction message: unexpected Solana transaction` +
+          ` type ${Object.getPrototypeOf(tx).constructor.name}`
+      );
+  }
+}

--- a/packages/swap/package.json
+++ b/packages/swap/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@enkryptcom/types": "workspace:^",
     "@enkryptcom/utils": "workspace:^",
+    "@solana/spl-token": "^0.4.8",
     "@solana/web3.js": "^1.95.3",
     "bignumber.js": "^9.1.2",
     "eventemitter3": "^5.0.1",

--- a/packages/swap/src/configs.ts
+++ b/packages/swap/src/configs.ts
@@ -98,9 +98,19 @@ const TOKEN_LISTS: {
   [NetworkNames.Telos]: `https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/${SupportedNetworkName.Telos}.json`,
 };
 
+/**
+ * ```sh
+ * curl -sL https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/changelly.json | jq '.' -C | less -R
+ * ```
+ */
 const CHANGELLY_LIST =
   "https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/changelly.json";
 
+/**
+ * ```sh
+ * curl -sL https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/top-tokens.json | jq '.' -C | less -R
+ * ```
+ */
 const TOP_TOKEN_INFO_LIST =
   "https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/top-tokens.json";
 

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -102,10 +102,12 @@ class Swap extends EventEmitter {
   }
 
   private async init() {
-    if (TOKEN_LISTS[this.network])
+    if (TOKEN_LISTS[this.network]) {
       this.tokenList = await fetch(TOKEN_LISTS[this.network]).then((res) =>
         res.json()
       );
+    }
+
     this.topTokenInfo = await fetch(TOP_TOKEN_INFO_LIST).then((res) =>
       res.json()
     );
@@ -117,7 +119,7 @@ class Swap extends EventEmitter {
         this.providers = [
           new Jupiter(this.api as Web3Solana, this.network),
           new Rango(this.api as Web3Solana, this.network),
-          new Changelly(this.network),
+          new Changelly(this.api, this.network),
         ];
         break;
       default:
@@ -125,7 +127,7 @@ class Swap extends EventEmitter {
         this.providers = [
           new OneInch(this.api as Web3Eth, this.network),
           new Paraswap(this.api as Web3Eth, this.network),
-          new Changelly(this.network),
+          new Changelly(this.api, this.network),
           new ZeroX(this.api as Web3Eth, this.network),
           new Rango(this.api as Web3Eth, this.network),
         ];

--- a/packages/swap/src/providers/changelly/index.ts
+++ b/packages/swap/src/providers/changelly/index.ts
@@ -1,7 +1,20 @@
+import type Web3Eth from "web3-eth";
 import { v4 as uuidv4 } from "uuid";
 import fetch from "node-fetch";
 import { fromBase, toBase } from "@enkryptcom/utils";
 import { numberToHex, toBN } from "web3-utils";
+import {
+  VersionedTransaction,
+  SystemProgram,
+  PublicKey,
+  TransactionMessage,
+  Connection,
+  TransactionInstruction,
+} from "@solana/web3.js";
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  createTransferInstruction as createSPLTransferInstruction,
+} from "@solana/spl-token";
 import {
   getQuoteOptions,
   MinMaxResponse,
@@ -32,9 +45,30 @@ import {
 
 import { getTransfer } from "../../utils/approvals";
 import supportedNetworks from "./supported";
-import { ChangellyCurrency } from "./types";
+import {
+  ChangellyApiCreateFixedRateTransactionParams,
+  ChangellyApiCreateFixedRateTransactionResult,
+  ChangellyApiGetFixRateForAmountParams,
+  ChangellyApiGetFixRateForAmountResult,
+  ChangellyApiGetFixRateParams,
+  ChangellyApiGetFixRateResult,
+  ChangellyApiGetStatusParams,
+  ChangellyApiGetStatusResult,
+  ChangellyApiResponse,
+  ChangellyApiValidateAddressParams,
+  ChangellyApiValidateAddressResult,
+  ChangellyCurrency,
+} from "./types";
 import estimateEVMGasList from "../../common/estimateGasList";
+import {
+  getCreateAssociatedTokenAccountIdempotentInstruction,
+  getSPLAssociatedTokenAccountPubkey,
+  getTokenProgramOfMint,
+  solAccountExists,
+  SPL_TOKEN_ATA_ACCOUNT_SIZE_BYTES,
+} from "../../utils/solana";
 
+/** Enables debug logging in this file */
 const DEBUG = false;
 
 const BASE_URL = "https://partners.mewapi.io/changelly-v2";
@@ -73,6 +107,8 @@ class Changelly extends ProviderClass {
 
   network: SupportedNetworkName;
 
+  web3: Web3Eth | Connection;
+
   name: ProviderName;
 
   fromTokens: ProviderFromTokenResponse;
@@ -84,8 +120,9 @@ class Changelly extends ProviderClass {
 
   contractToTicker: Record<string, string>;
 
-  constructor(network: SupportedNetworkName) {
+  constructor(web3: Web3Eth | Connection, network: SupportedNetworkName) {
     super();
+    this.web3 = web3;
     this.network = network;
     this.tokenList = [];
     this.name = ProviderName.changelly;
@@ -105,8 +142,7 @@ class Changelly extends ProviderClass {
     }
     this.changellyList = await fetch(CHANGELLY_LIST).then((res) => res.json());
 
-    /** Mapping of changelly network name -> enkrypt network name */
-    /** changelly blockchain name -> enkrypt supported swap network name */
+    /** Changelly blockchain name -> enkrypt supported swap network name */
     const changellyToNetwork: Record<string, SupportedNetworkName> = {};
     // Generate mapping of changelly blockchain -> enkrypt blockchain
     Object.keys(supportedNetworks).forEach((net) => {
@@ -180,36 +216,99 @@ class Changelly extends ProviderClass {
     );
   }
 
-  private changellyRequest(method: string, params: any): Promise<any> {
-    // TODO: timeoutes & retries?
-    return fetch(`${BASE_URL}`, {
-      method: "POST",
-      body: JSON.stringify({
-        id: uuidv4(),
-        jsonrpc: "2.0",
-        method,
-        params,
-      }),
-      headers: { "Content-Type": "application/json" },
-    }).then((res) => res.json());
+  /**
+   * Make a HTTP request to the Changelly Json RPC API
+   *
+   * @param method  JsonRPC request method
+   * @param params  JsonRPC request parameters
+   * @param context Cancellable execution context
+   * @returns       JsonRPC response, could be success or error
+   */
+  private async changellyRequest<T>(
+    method: string,
+    params: any,
+    context?: { signal?: AbortSignal }
+  ): Promise<ChangellyApiResponse<T>> {
+    const signal = context?.signal;
+    const aborter = new AbortController();
+    function onAbort() {
+      // Pass context signal to the request signal
+      aborter.abort(signal!.reason);
+    }
+    function onTimeout() {
+      aborter.abort(
+        new Error(`Changelly API request timed out ${BASE_URL} ${method}`)
+      );
+    }
+    function cleanup() {
+      // eslint-disable-next-line no-use-before-define
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+    }
+    const timeout = setTimeout(onTimeout, 30_000);
+    signal?.addEventListener("abort", onAbort);
+    try {
+      const response = await fetch(BASE_URL, {
+        method: "POST",
+        signal: aborter.signal,
+        body: JSON.stringify({
+          id: uuidv4(),
+          jsonrpc: "2.0",
+          method,
+          params,
+        }),
+        headers: [
+          ["Content-Type", "application/json"],
+          ["Accept", "application/json"],
+        ],
+      });
+      const json = (await response.json()) as ChangellyApiResponse<T>;
+      return json;
+    } finally {
+      cleanup();
+    }
   }
 
-  isValidAddress(address: string, ticker: string): Promise<boolean> {
-    return this.changellyRequest("validateAddress", {
+  async isValidAddress(address: string, ticker: string): Promise<boolean> {
+    const params: ChangellyApiValidateAddressParams = {
       currency: ticker,
       address,
-    }).then((response) => {
-      if (response.error) {
-        debug(
-          "isValidAddress",
-          `Error in response when validating address` +
-            `  address=${address}` +
-            `  err=${String(response.error.message)}`
-        );
-        return false;
-      }
-      return response.result?.[0]?.result ?? false;
-    });
+    };
+
+    /** @see https://docs.changelly.com/validate-address */
+    const response =
+      await this.changellyRequest<ChangellyApiValidateAddressResult>(
+        "validateAddress",
+        params
+      );
+
+    if (response.error) {
+      console.warn(
+        `Error validating address with via Changelly` +
+          `  code=${String(response.error.code)}` +
+          `  message=${String(response.error.message)}`
+      );
+      return false;
+    }
+
+    if (typeof response.result.result !== "boolean") {
+      console.warn(
+        'Unexpected response to "validateAddress" call to Changelly.' +
+          ` Expected a response.result.result to be a boolean` +
+          ` but received response: ${JSON.stringify(response)}`
+      );
+      return false;
+    }
+
+    const isValid = response.result.result;
+    debug(
+      "isValidAddress",
+      `Changelly validateAddress result` +
+        `  address=${address}` +
+        `  ticker=${ticker}` +
+        `  isValid=${isValid}`
+    );
+    return isValid;
   }
 
   getFromTokens() {
@@ -221,71 +320,86 @@ class Changelly extends ProviderClass {
     return {};
   }
 
-  getMinMaxAmount({
-    fromToken,
-    toToken,
-  }: {
-    fromToken: TokenType;
-    toToken: TokenTypeTo;
-  }): Promise<MinMaxResponse> {
+  async getMinMaxAmount(
+    options: { fromToken: TokenType; toToken: TokenTypeTo },
+    context?: { signal?: AbortSignal }
+  ): Promise<MinMaxResponse> {
+    const { fromToken, toToken } = options;
+    const signal = context?.signal;
+
     const startedAt = Date.now();
-    debug(
-      "getMinMaxAmount",
-      `Getting min and max of swap pair` +
-        `  fromToken=${fromToken.symbol}` +
-        `  toToken=${toToken.symbol}`
-    );
     const emptyResponse = {
       minimumFrom: toBN("0"),
       maximumFrom: toBN("0"),
       minimumTo: toBN("0"),
       maximumTo: toBN("0"),
     };
-    const method = "getFixRate";
-    return this.changellyRequest(method, {
-      from: this.getTicker(fromToken, this.network),
-      to: this.getTicker(
-        toToken as TokenType,
-        toToken.networkInfo.name as SupportedNetworkName
-      ),
-    })
-      .then((response) => {
-        if (response.error) return emptyResponse;
-        const result = response.result[0];
-        const minMax = {
-          minimumFrom: toBN(toBase(result.minFrom, fromToken.decimals)),
-          maximumFrom: toBN(toBase(result.maxFrom, fromToken.decimals)),
-          minimumTo: toBN(toBase(result.minTo, toToken.decimals)),
-          maximumTo: toBN(toBase(result.maxTo, toToken.decimals)),
-        };
-        debug(
-          "getMinMaxAmount",
-          `Successfully got min and max of swap pair` +
-            `  method=${method}` +
-            `  fromToken=${fromToken.symbol}` +
-            `  toToken=${toToken.symbol}` +
-            `  took=${(Date.now() - startedAt).toLocaleString()}ms`
+
+    try {
+      const params: ChangellyApiGetFixRateParams = {
+        from: this.getTicker(fromToken, this.network),
+        to: this.getTicker(
+          toToken as TokenType,
+          toToken.networkInfo.name as SupportedNetworkName
+        ),
+      };
+
+      const response =
+        await this.changellyRequest<ChangellyApiGetFixRateResult>(
+          "getFixRate",
+          params,
+          { signal }
         );
-        return minMax;
-      })
-      .catch((err: Error) => {
-        debug(
-          "getMinMaxAmount",
-          `Errored calling getFixRate to get the min and max of swap pair` +
-            `  method=${method}` +
-            `  fromToken=${fromToken.symbol}` +
-            `  toToken=${toToken.symbol}` +
+
+      if (response.error) {
+        // JsonRPC ERR response
+        console.warn(
+          `Changelly "getFixRate" returned JSONRPC error response` +
+            `  fromToken=${fromToken.symbol} (${params.from})` +
+            `  toToken=${toToken.symbol} (${params.to})` +
             `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
-            `  err=${String(err)}`
+            `  code=${String(response.error.code)}` +
+            `  message=${String(response.error.message)}`
         );
         return emptyResponse;
-      });
+      }
+
+      // JsonRPC OK response
+      const result = response.result[0];
+      const minMax = {
+        minimumFrom: toBN(toBase(result.minFrom, fromToken.decimals)),
+        maximumFrom: toBN(toBase(result.maxFrom, fromToken.decimals)),
+        minimumTo: toBN(toBase(result.minTo, toToken.decimals)),
+        maximumTo: toBN(toBase(result.maxTo, toToken.decimals)),
+      };
+      debug(
+        "getMinMaxAmount",
+        `Successfully got min and max of swap pair` +
+          `  fromToken=${fromToken.symbol} (${params.from})` +
+          `  toToken=${toToken.symbol} (${params.to})` +
+          `  took=${(Date.now() - startedAt).toLocaleString()}ms`
+      );
+      return minMax;
+    } catch (err) {
+      // HTTP request failed
+      console.warn(
+        `Errored calling Changelly JSONRPC HTTP API "getFixRate"` +
+          `  fromToken=${fromToken.symbol}` +
+          `  toToken=${toToken.symbol}` +
+          `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+          `  err=${String(err)}`
+      );
+      return emptyResponse;
+    }
   }
 
   async getQuote(
     options: getQuoteOptions,
-    meta: QuoteMetaOptions
+    meta: QuoteMetaOptions,
+    context?: { signal?: AbortSignal }
   ): Promise<ProviderQuoteResponse | null> {
+    const signal = context?.signal;
+
     const startedAt = Date.now();
 
     debug(
@@ -361,91 +475,189 @@ class Changelly extends ProviderClass {
 
     if (quoteRequestAmount.toString() === "0") return null;
 
-    const method = "getFixRateForAmount";
-    debug("getQuote", `Requesting changelly swap...  method=${method}`);
-    return this.changellyRequest(method, {
-      from: this.getTicker(options.fromToken, this.network),
-      to: this.getTicker(
-        options.toToken as TokenType,
-        options.toToken.networkInfo.name as SupportedNetworkName
-      ),
-      amountFrom: fromBase(
-        quoteRequestAmount.toString(),
-        options.fromToken.decimals
-      ),
-    })
-      .then(async (response) => {
-        debug("getQuote", `Received Changelly swap response  method=${method}`);
-        if (response.error || !response.result || !response.result[0].id) {
-          debug(
-            "getQuote",
-            `No swap: response either contains error, no result or no id` +
-              `  method=${method}` +
-              `  took=${(Date.now() - startedAt).toLocaleString()}ms`
-          );
-          return null;
-        }
-        const result = response.result[0];
-        const evmGasLimit =
-          options.fromToken.address === NATIVE_TOKEN_ADDRESS &&
-          options.fromToken.type === NetworkType.EVM
-            ? 21000
-            : toBN(GAS_LIMITS.transferToken).toNumber();
-        const retResponse: ProviderQuoteResponse = {
-          fromTokenAmount: quoteRequestAmount,
-          additionalNativeFees: toBN(0),
-          toTokenAmount: toBN(
-            toBase(result.amountTo, options.toToken.decimals)
-          ).sub(toBN(toBase(result.networkFee, options.toToken.decimals))),
-          provider: this.name,
-          quote: {
-            meta: {
-              ...meta,
-              changellyQuoteId: result.id,
-              changellynetworkFee: toBN(
-                toBase(result.networkFee, options.toToken.decimals)
-              ),
-            },
-            options: {
-              ...options,
-              amount: quoteRequestAmount,
-            },
-            provider: this.name,
-          },
-          totalGaslimit:
-            options.fromToken.type === NetworkType.EVM ? evmGasLimit : 0,
-          minMax,
-        };
-        debug(
-          "getQuote",
-          `Successfully processed Changelly swap response` +
-            `  took=${(Date.now() - startedAt).toLocaleString()}ms`
+    debug("getQuote", `Requesting changelly swap...`);
+
+    try {
+      const params: ChangellyApiGetFixRateForAmountParams = {
+        from: this.getTicker(options.fromToken, this.network),
+        to: this.getTicker(
+          options.toToken as TokenType,
+          options.toToken.networkInfo.name as SupportedNetworkName
+        ),
+        amountFrom: fromBase(
+          quoteRequestAmount.toString(),
+          options.fromToken.decimals
+        ),
+      };
+
+      const response =
+        await this.changellyRequest<ChangellyApiGetFixRateForAmountResult>(
+          "getFixRateForAmount",
+          params,
+          { signal }
         );
-        return retResponse;
-      })
-      .catch((err) => {
-        debug(
-          "getQuote",
-          `Changelly request failed` +
-            `  method=${method}` +
+
+      debug("getQuote", `Received Changelly swap response`);
+
+      if (response.error) {
+        console.warn(
+          `Changelly "getFixRateForAmount" returned JSONRPC error response,` +
+            ` returning no quotes` +
+            `  fromToken=${options.fromToken.symbol} (${params.from})` +
+            `  toToken=${options.toToken.symbol} (${params.to})` +
             `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
-            `  err=${String(err)}`
+            `  code=${String(response.error.code)}` +
+            `  message=${String(response.error.message)}`
         );
         return null;
-      });
+      }
+
+      if (!response.result || !response.result[0]?.id) {
+        console.warn(
+          `Changelly "getFixRateForAmount" response contains no quotes,` +
+            ` returning no quotes` +
+            `  fromToken=${options.fromToken.symbol} (${params.from})` +
+            `  toToken=${options.toToken.symbol} (${params.to})` +
+            `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+            `  code=${String(response.error.code)}` +
+            `  message=${String(response.error.message)}`,
+          { ...response }
+        );
+        return null;
+      }
+
+      // TODO: Do we want to warn here? or just debug log? or nothing?
+      if (response.result.length > 1) {
+        console.warn(
+          `Changelly "getFixRateForAmount" returned more than one quote, continuing with first quote` +
+            `  fromToken=${options.fromToken.symbol} (${params.from})` +
+            `  toToken=${options.toToken.symbol} (${params.to})` +
+            `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+            `  count=${response.result.length}ms`,
+          { ...response }
+        );
+      }
+
+      const [firstChangellyFixRateQuote] = response.result;
+
+      const evmGasLimit =
+        options.fromToken.address === NATIVE_TOKEN_ADDRESS &&
+        options.fromToken.type === NetworkType.EVM
+          ? 21000
+          : toBN(GAS_LIMITS.transferToken).toNumber();
+
+      // `toBase` fails sometimes because Changelly returns more decimals than the token has
+      let toTokenAmountBase: string;
+      try {
+        toTokenAmountBase = toBase(
+          firstChangellyFixRateQuote.amountTo,
+          options.toToken.decimals
+        );
+      } catch (err) {
+        console.warn(
+          `Changelly "getFixRateForAmount" "amountTo" possibly returned more` +
+            ` decimals than the token has, attempting to trim trailing decimals...` +
+            `  amountTo=${firstChangellyFixRateQuote.amountTo}` +
+            `  toTokenDecimals=${options.toToken.decimals}` +
+            `  err=${String(err)}`
+        );
+        const original = firstChangellyFixRateQuote.amountTo;
+        // eslint-disable-next-line no-use-before-define
+        const [success, fixed] = trimDecimals(
+          original,
+          options.toToken.decimals
+        );
+        if (!success) throw err;
+        const rounded = (
+          BigInt(toBase(fixed, options.toToken.decimals)) - BigInt(1)
+        ).toString();
+        toTokenAmountBase = rounded;
+      }
+
+      // `toBase` fails sometimes because Changelly returns more decimals than the token has
+      let networkFeeBase: string;
+      try {
+        networkFeeBase = toBase(
+          firstChangellyFixRateQuote.networkFee,
+          options.toToken.decimals
+        );
+      } catch (err) {
+        console.warn(
+          `Changelly "getFixRateForAmount" "networkFee" possibly returned more` +
+            ` decimals than the token has, attempting to trim trailing decimals...` +
+            `  networkFee=${firstChangellyFixRateQuote.networkFee}` +
+            `  toTokenDecimals=${options.toToken.decimals}` +
+            `  err=${String(err)}`
+        );
+        const original = firstChangellyFixRateQuote.networkFee;
+        // eslint-disable-next-line no-use-before-define
+        const [success, fixed] = trimDecimals(
+          original,
+          options.toToken.decimals
+        );
+        if (!success) throw err;
+        const rounded = (
+          BigInt(toBase(fixed, options.toToken.decimals)) + BigInt(1)
+        ).toString();
+        networkFeeBase = rounded;
+      }
+
+      const providerQuoteResponse: ProviderQuoteResponse = {
+        fromTokenAmount: quoteRequestAmount,
+        additionalNativeFees: toBN(0),
+        toTokenAmount: toBN(toTokenAmountBase).sub(toBN(networkFeeBase)),
+        provider: this.name,
+        quote: {
+          meta: {
+            ...meta,
+            changellyQuoteId: firstChangellyFixRateQuote.id,
+            changellynetworkFee: toBN(networkFeeBase),
+          },
+          options: {
+            ...options,
+            amount: quoteRequestAmount,
+          },
+          provider: this.name,
+        },
+        totalGaslimit:
+          options.fromToken.type === NetworkType.EVM ? evmGasLimit : 0,
+        minMax,
+      };
+
+      debug(
+        "getQuote",
+        `Successfully retrieved quote from Changelly via "getFixRateForAmount"` +
+          `  took=${(Date.now() - startedAt).toLocaleString()}ms`
+      );
+
+      return providerQuoteResponse;
+    } catch (err) {
+      console.warn(
+        `Errored getting quotes from Changelly via "getFixRateForAmount",` +
+          ` returning no quotes` +
+          `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+          `  err=${String(err)}`
+      );
+      return null;
+    }
   }
 
-  getSwap(quote: SwapQuote): Promise<ProviderSwapResponse | null> {
+  async getSwap(
+    quote: SwapQuote,
+    context?: { signal?: AbortSignal }
+  ): Promise<ProviderSwapResponse | null> {
+    const signal = context?.signal;
+
     const startedAt = Date.now();
-    debug("getSwap", `Getting Changelly swap`);
+    debug("getSwap", `Requesting swap transaction from Changelly...`);
 
     if (!Changelly.isSupported(this.network)) {
       debug(
         "getSwap",
-        `No swap: Enkrypt does not support Changelly on the source network` +
+        `Enkrypt does not support Changelly on the source network, returning no swap` +
           `  srcNetwork=${this.network}`
       );
-      return Promise.resolve(null);
+      return null;
     }
 
     if (
@@ -455,58 +667,81 @@ class Changelly extends ProviderClass {
     ) {
       debug(
         "getSwap",
-        `No swap: Enkrypt does not support Changelly on the destination network` +
+        `Enkrypt does not support Changelly on the destination network, returning no swap` +
           `  dstNetwork=${quote.options.toToken.networkInfo.name}`
       );
-      return Promise.resolve(null);
+      return null;
     }
 
-    const method = "createFixTransaction";
-    debug("getSwap", `Requesting Changelly swap...  method=${method}`);
-    return this.changellyRequest("createFixTransaction", {
-      from: this.getTicker(quote.options.fromToken, this.network),
-      to: this.getTicker(
-        quote.options.toToken as TokenType,
-        quote.options.toToken.networkInfo.name as SupportedNetworkName
-      ),
-      refundAddress: quote.options.fromAddress,
-      address: quote.options.toAddress,
-      amountFrom: fromBase(
-        quote.options.amount.toString(),
-        quote.options.fromToken.decimals
-      ),
-      rateId: quote.meta.changellyQuoteId,
-    })
-      .then(async (response) => {
-        debug("getSwap", `Received Changelly swap response  method=${method}`);
-        if (response.error || !response.result.id) {
-          debug(
-            "getSwap",
-            `No swap: response either contains error or no id` +
-              `  method=${method}` +
-              `  took=${(Date.now() - startedAt).toLocaleString()}ms`
-          );
-          return null;
-        }
-        const { result } = response;
-        let transaction: SwapTransaction;
-        if (quote.options.fromToken.type === NetworkType.EVM) {
-          if (quote.options.fromToken.address === NATIVE_TOKEN_ADDRESS)
+    try {
+      const params: ChangellyApiCreateFixedRateTransactionParams = {
+        from: this.getTicker(quote.options.fromToken, this.network),
+        to: this.getTicker(
+          quote.options.toToken as TokenType,
+          quote.options.toToken.networkInfo.name as SupportedNetworkName
+        ),
+        refundAddress: quote.options.fromAddress,
+        address: quote.options.toAddress,
+        amountFrom: fromBase(
+          quote.options.amount.toString(),
+          quote.options.fromToken.decimals
+        ),
+        rateId: quote.meta.changellyQuoteId,
+      };
+
+      const response =
+        await this.changellyRequest<ChangellyApiCreateFixedRateTransactionResult>(
+          "createFixTransaction",
+          params,
+          { signal }
+        );
+
+      if (response.error) {
+        console.warn(
+          `Changelly "createFixTransaction" returned JSONRPC error response, returning no swap` +
+            `  fromToken=${quote.options.fromToken.symbol} (${params.from})` +
+            `  toToken=${quote.options.toToken.symbol} (${params.to})` +
+            `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+            `  code=${String(response.error.code)}` +
+            `  message=${String(response.error.message)}`
+        );
+        return null;
+      }
+
+      if (!response.result.id) {
+        console.warn(
+          `Changelly "createFixTransaction" response contains no id, returning no swap` +
+            `  fromToken=${quote.options.fromToken.symbol} (${params.from})` +
+            `  toToken=${quote.options.toToken.symbol} (${params.to})` +
+            `  took=${(Date.now() - startedAt).toLocaleString()}ms`,
+          { ...response }
+        );
+        return null;
+      }
+
+      let additionalNativeFees = toBN(0);
+      const changellyFixedRateTx = response.result;
+      let transaction: SwapTransaction;
+      switch (quote.options.fromToken.type) {
+        case NetworkType.EVM: {
+          debug("getSwap", `Preparing EVM transaction for Changelly swap`);
+          if (quote.options.fromToken.address === NATIVE_TOKEN_ADDRESS) {
             transaction = {
               from: quote.options.fromAddress,
               data: "0x",
               gasLimit: numberToHex(21000),
-              to: result.payinAddress,
+              to: changellyFixedRateTx.payinAddress,
               value: numberToHex(quote.options.amount),
               type: TransactionType.evm,
             };
-          else
+          } else {
             transaction = getTransfer({
               from: quote.options.fromAddress,
               contract: quote.options.fromToken.address,
-              to: result.payinAddress,
+              to: changellyFixedRateTx.payinAddress,
               value: quote.options.amount.toString(),
             });
+          }
           const accurateGasEstimate = await estimateEVMGasList(
             [transaction],
             this.network
@@ -516,75 +751,256 @@ class Changelly extends ProviderClass {
             const [txGaslimit] = accurateGasEstimate.result;
             transaction.gasLimit = txGaslimit;
           }
-        } else {
+          break;
+        }
+        case NetworkType.Solana: {
+          // TODO: finish implementing support for Solana
+          debug("getSwap", `Changelly is not supported on Solana at this time`);
+          if (true as any) return null;
+
+          const latestBlockHash = await (
+            this.web3 as Connection
+          ).getLatestBlockhash();
+
+          // Create a transaction to transfer this much of that token to that thing
+          let versionedTx: VersionedTransaction;
+          if (quote.options.fromToken.address === NATIVE_TOKEN_ADDRESS) {
+            debug(
+              "getSwap",
+              `Preparing Solana Changelly SOL swap transaction` +
+                `  quote.options.fromAddress=${quote.options.fromAddress}` +
+                `  latestBlockHash=${latestBlockHash.blockhash}` +
+                `  lastValidBlockHeight=${latestBlockHash.lastValidBlockHeight}` +
+                `  payinAddress=${changellyFixedRateTx.payinAddress}` +
+                `  lamports=${BigInt(quote.options.amount.toString())}`
+            );
+            versionedTx = new VersionedTransaction(
+              new TransactionMessage({
+                payerKey: new PublicKey(quote.options.fromAddress),
+                recentBlockhash: latestBlockHash.blockhash,
+                instructions: [
+                  SystemProgram.transfer({
+                    fromPubkey: new PublicKey(quote.options.fromAddress),
+                    toPubkey: new PublicKey(changellyFixedRateTx.payinAddress),
+                    lamports: BigInt(quote.options.amount.toString()),
+                  }),
+                ],
+              }).compileToV0Message()
+            );
+          } else {
+            const wallet = new PublicKey(quote.options.fromAddress);
+            const mint = new PublicKey(quote.options.fromToken.address);
+            const tokenProgramId = await getTokenProgramOfMint(
+              this.web3 as Connection,
+              mint
+            );
+            const walletMintAta = getSPLAssociatedTokenAccountPubkey(
+              wallet,
+              mint,
+              tokenProgramId
+            );
+            // TODO: is payin address an ATA or Wallet address?
+            const payinAta = new PublicKey(changellyFixedRateTx.payinAddress);
+            const amount = BigInt(quote.options.amount.toString());
+            debug(
+              "getSwap",
+              // eslint-disable-next-line prefer-template
+              `Preparing Solana Changelly SPL token swap transaction` +
+                `  srcMint=${mint.toBase58()}` +
+                `  wallet=${wallet.toBase58()}` +
+                `  walletSrcMintAta=${tokenProgramId.toBase58()}` +
+                `  dstMintAta=${payinAta.toBase58()}` +
+                `  tokenProgramId=${tokenProgramId.toBase58()}` +
+                `  latestBlockHash=${latestBlockHash.blockhash}` +
+                `  lastValidBlockHeight=${latestBlockHash.lastValidBlockHeight}` +
+                `  payinAddress=${changellyFixedRateTx.payinAddress}` +
+                `  amount=${amount}`
+            );
+
+            // If the ATA account doesn't exist we need create it
+            const ataExists = await solAccountExists(
+              this.web3 as Connection,
+              payinAta
+            );
+
+            const instructions: TransactionInstruction[] = [];
+            if (ataExists) {
+              debug(
+                "getSwap",
+                `Payin ATA already exists. No need to create it.`
+              );
+            } else {
+              debug("getSwap", `Payin ATA does not exist. Need to create it.`);
+              // TODO: finish implementing
+              const extraRentFee = await (
+                this.web3 as Connection
+              ).getMinimumBalanceForRentExemption(
+                SPL_TOKEN_ATA_ACCOUNT_SIZE_BYTES
+              );
+              const instruction =
+                getCreateAssociatedTokenAccountIdempotentInstruction({
+                  payerPubkey: wallet,
+                  ataPubkey: payinAta, // TODO: we'd need to get the owner
+                  ownerPubkey: new PublicKey("!! TODO !!"),
+                  mintPubkey: mint,
+                  systemProgramId: SystemProgram.programId,
+                  tokenProgramId,
+                  associatedTokenProgramId: ASSOCIATED_TOKEN_PROGRAM_ID,
+                });
+
+              instructions.push(instruction);
+              additionalNativeFees = additionalNativeFees.add(
+                toBN(extraRentFee)
+              );
+              throw new Error("TODO: Finish implementing Changelly on Solana");
+            }
+
+            instructions.push(
+              createSPLTransferInstruction(
+                /** source */ walletMintAta,
+                /** destination */ payinAta,
+                /** owner */ wallet,
+                /** amount */ amount,
+                /** multiSigners */ [],
+                /** programId */ tokenProgramId
+              )
+            );
+
+            versionedTx = new VersionedTransaction(
+              new TransactionMessage({
+                payerKey: wallet,
+                recentBlockhash: latestBlockHash.blockhash,
+                instructions,
+              }).compileToV0Message()
+            );
+          }
+
+          transaction = {
+            type: TransactionType.solana,
+            from: quote.options.fromAddress,
+            to: changellyFixedRateTx.payinAddress,
+            serialized: Buffer.from(versionedTx.serialize()).toString("base64"),
+            kind: "versioned",
+            signed: false,
+          };
+          break;
+        }
+        default: {
           transaction = {
             from: quote.options.fromAddress,
-            to: result.payinAddress,
+            to: changellyFixedRateTx.payinAddress,
             value: numberToHex(quote.options.amount),
             type: TransactionType.generic,
           };
+          break;
         }
-        const fee = 1;
-        const retResponse: ProviderSwapResponse = {
-          fromTokenAmount: quote.options.amount,
-          provider: this.name,
-          toTokenAmount: toBN(
-            toBase(result.amountExpectedTo, quote.options.toToken.decimals)
-          ).sub(quote.meta.changellynetworkFee),
-          additionalNativeFees: toBN(0),
-          transactions: [transaction],
-          slippage: quote.meta.slippage || DEFAULT_SLIPPAGE,
-          fee,
-          getStatusObject: async (
-            options: StatusOptions
-          ): Promise<StatusOptionsResponse> => ({
-            options: {
-              ...options,
-              swapId: result.id,
-            },
-            provider: this.name,
-          }),
-        };
-        debug(
-          "getSwap",
-          `Successfully processed Changelly swap response` +
-            `  took=${(Date.now() - startedAt).toLocaleString()}ms`
+      }
+
+      // `toBase` fails sometimes because Changelly returns more decimals than the token has
+      const fee = 1;
+      let baseToAmount: string;
+      try {
+        baseToAmount = toBase(
+          changellyFixedRateTx.amountExpectedTo,
+          quote.options.toToken.decimals
         );
-        return retResponse;
-      })
-      .catch((err) => {
-        debug(
-          "getSwap",
-          `Changelly request failed` +
-            `  method=${method}` +
-            `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+      } catch (err) {
+        console.warn(
+          `Changelly "createFixTransaction" "amountExpectedTo" possibly returned more` +
+            ` decimals than the token has, attempting to trim trailing decimals...` +
+            `  amountExpectedTo=${changellyFixedRateTx.amountExpectedTo}` +
+            `  toTokenDecimals=${quote.options.toToken.decimals}` +
             `  err=${String(err)}`
         );
-        return null;
-      });
+        const original = changellyFixedRateTx.amountExpectedTo;
+        // eslint-disable-next-line no-use-before-define
+        const [success, fixed] = trimDecimals(
+          original,
+          quote.options.toToken.decimals
+        );
+        if (!success) throw err;
+        const rounded = (
+          BigInt(toBase(fixed, quote.options.toToken.decimals)) - BigInt(1)
+        ).toString();
+        baseToAmount = rounded;
+      }
+
+      const retResponse: ProviderSwapResponse = {
+        fromTokenAmount: quote.options.amount,
+        provider: this.name,
+        toTokenAmount: toBN(baseToAmount).sub(quote.meta.changellynetworkFee),
+        additionalNativeFees,
+        transactions: [transaction],
+        slippage: quote.meta.slippage || DEFAULT_SLIPPAGE,
+        fee,
+        getStatusObject: async (
+          options: StatusOptions
+        ): Promise<StatusOptionsResponse> => ({
+          options: {
+            ...options,
+            swapId: changellyFixedRateTx.id,
+          },
+          provider: this.name,
+        }),
+      };
+      debug(
+        "getSwap",
+        `Successfully extracted Changelly swap transaction via "createFixTransaction"` +
+          `  took=${(Date.now() - startedAt).toLocaleString()}ms`
+      );
+      return retResponse;
+    } catch (err) {
+      console.warn(
+        `Errored processing Changelly swap response, returning no swap` +
+          `  took=${(Date.now() - startedAt).toLocaleString()}ms` +
+          `  err=${String(err)}`
+      );
+      return null;
+    }
   }
 
-  getStatus(options: StatusOptions): Promise<TransactionStatus> {
-    return this.changellyRequest("getStatus", {
+  async getStatus(options: StatusOptions): Promise<TransactionStatus> {
+    const params: ChangellyApiGetStatusParams = {
       id: options.swapId,
-    }).then(async (response) => {
-      if (response.error || !response.result) return TransactionStatus.pending;
-      const completedStatuses = ["finished"];
-      const pendingStatuses = [
-        "confirming",
-        "exchanging",
-        "sending",
-        "waiting",
-        "new",
-      ];
-      const failedStatuses = ["failed", "refunded", "hold", "expired"];
-      const status = response.result;
-      if (pendingStatuses.includes(status)) return TransactionStatus.pending;
-      if (completedStatuses.includes(status)) return TransactionStatus.success;
-      if (failedStatuses.includes(status)) return TransactionStatus.failed;
-      return TransactionStatus.pending;
-    });
+    };
+    const response = await this.changellyRequest<ChangellyApiGetStatusResult>(
+      "getStatus",
+      params
+    );
+
+    if (response.error || !response.result) return TransactionStatus.pending;
+    const completedStatuses = ["finished"];
+    const pendingStatuses = [
+      "confirming",
+      "exchanging",
+      "sending",
+      "waiting",
+      "new",
+    ];
+    const failedStatuses = ["failed", "refunded", "hold", "expired"];
+    const status = response.result;
+    if (pendingStatuses.includes(status)) return TransactionStatus.pending;
+    if (completedStatuses.includes(status)) return TransactionStatus.success;
+    if (failedStatuses.includes(status)) return TransactionStatus.failed;
+    return TransactionStatus.pending;
   }
+}
+
+function trimDecimals(
+  value: string,
+  decimals: number
+): [success: boolean, fixed: string] {
+  const original = value;
+  const parts = original.split(".");
+  if (parts.length !== 2) return [false, ""]; // More or less than one decimal, something else is wrong
+  // Possibly recoverable
+  const [integerPart, fractionPart] = parts;
+  if (fractionPart.length <= decimals) return [false, ""]; // Some other issue, decimals should be sufficient
+  const fractionTrimmed = fractionPart.slice(0, decimals);
+  const normalised = `${integerPart}.${fractionTrimmed}`;
+  // Round up one (higher price paid) since we lose precision
+  const rounded = (BigInt(toBase(normalised, decimals)) + BigInt(1)).toString();
+  return [true, rounded];
 }
 
 export default Changelly;

--- a/packages/swap/src/providers/changelly/supported.ts
+++ b/packages/swap/src/providers/changelly/supported.ts
@@ -1,6 +1,6 @@
-import { PublicKey } from "@solana/web3.js";
 import { isPolkadotAddress, isEVMAddress } from "../../utils/common";
 import { SupportedNetworkName } from "../../types";
+// import { isValidSolanaAddress } from "../../utils/solana";
 
 /**
  * Blockchain names:
@@ -61,18 +61,13 @@ const supportedNetworks: {
   [SupportedNetworkName.Dogecoin]: {
     changellyName: "doge",
   },
-  [SupportedNetworkName.Solana]: {
-    changellyName: "solana",
-    isAddress: (address: string) => {
-      try {
-        // eslint-disable-next-line no-new
-        new PublicKey(address);
-        return Promise.resolve(true);
-      } catch (err) {
-        return Promise.resolve(false);
-      }
-    },
-  },
+  // TODO: Support Solana
+  // [SupportedNetworkName.Solana]: {
+  //   changellyName: "solana",
+  //   async isAddress(address: string) {
+  //     return isValidSolanaAddress(address);
+  //   },
+  // },
   [SupportedNetworkName.Rootstock]: {
     changellyName: "rootstock",
   },

--- a/packages/swap/src/providers/changelly/types.ts
+++ b/packages/swap/src/providers/changelly/types.ts
@@ -17,3 +17,699 @@ export interface ChangellyCurrency {
   contractAddress?: string;
   token?: TokenType;
 }
+
+// Changelly's API is Json RPC
+
+export type ChangellyApiOkResponse<T> = {
+  id: string | number;
+  jsonrpc: "2.0";
+  result: T;
+  error?: undefined;
+};
+export type ChangellyApiErrResponse = {
+  id: string | number;
+  jsonrpc: "2.0";
+  result?: undefined;
+  error: {
+    message: string;
+    code: number;
+  };
+};
+
+export type ChangellyApiResponse<T> =
+  | ChangellyApiOkResponse<T>
+  | ChangellyApiErrResponse;
+
+/**
+ * @see https://docs.changelly.com/validate-address#request
+ *
+ * @example
+ * ```sh
+ * # Valid address
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"validateAddress","params":{"currency":"sol","address":"CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38"}}' | jq '.' -C | less -R
+ * # {
+ * #   "jsonrpc": "2.0",
+ * #   "result": {
+ * #     "result": true
+ * #   },
+ * #   "id": "1"
+ * # }
+ *
+ * # Invalid address
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"validateAddress","params":{"currency":"sol","address":"CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38zzzzzz"}}' | jq '.' -C | less -R
+ * # {
+ * #   "jsonrpc": "2.0",
+ * #   "result": {
+ * #     "result": false,
+ * #     "message": "Invalid address"
+ * #   },
+ * #   "id": "1"
+ * # }
+ * ```
+ */
+export type ChangellyApiValidateAddressParams = {
+  /**
+   * Currency ticker (in lowercase).
+   *
+   * @example "sol"
+   */
+  currency: string;
+
+  /**
+   * Wallet address.
+   *
+   * @example "CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38"
+   */
+  address: string;
+
+  /** Extra ID. */
+  extraId?: string;
+};
+
+/** @see https://docs.changelly.com/validate-address#response */
+export type ChangellyApiValidateAddressResult = {
+  /**
+   * Is true if the given address is valid.
+   */
+  result: boolean;
+
+  /**
+   * Error message which is returned only if the given address is invalid.
+   *
+   * @example "Invalid address"
+   */
+  message?: string;
+};
+
+/**
+ * @see https://docs.changelly.com/fix/get-fix-rate#request
+ *
+ * @note The method is deprecated. Use getFixRateForAmount instead.
+ *
+ * @example
+ * ```sh
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getFixRate","params":{"from":"sol","to":"btc"}}' | jq '.' -C | less -R
+ * # {
+ * #   "jsonrpc": "2.0",
+ * #   "result": [
+ * #     {
+ * #       "id": "RmELQQZ@MP0WIcD55XEjyVmieqsk@z",
+ * #       "from": "sol",
+ * #       "to": "btc",
+ * #       "result": "0.002190975020",
+ * #       "networkFee": "0.00001909",
+ * #       "max": "700.00000000",
+ * #       "maxFrom": "700.00000000",
+ * #       "maxTo": "1.57946710",
+ * #       "min": "0.80000000",
+ * #       "minFrom": "0.80000000",
+ * #       "minTo": "0.00180510",
+ * #       "expiredAt": 1726539462
+ * #     }
+ * #   ],
+ * #   "id": "1"
+ * # }
+ * ````
+ */
+export type ChangellyApiGetFixRateParams = {
+  /**
+   * Payin currency code (in lowercase).
+   *
+   * @example "sol"
+   */
+  from: string;
+
+  /**
+   * Payout currency code (in lowercase).
+   *
+   * @example "btc"
+   * */
+  to: string;
+};
+
+/**
+ * @see https://docs.changelly.com/fix/get-fix-rate#response
+ *
+ * @note The method is deprecated. Use getFixRateForAmount instead.
+ */
+export type ChangellyApiGetFixRateResult = Array<{
+  /**
+   * Rate ID that can be used during 1 minute.
+   * This time should be enough for user to initiate the exchange.
+   * Expired rate id cannot be used for creation of the fixed rate transaction.
+   *
+   * id has to be stored somewhere. It will be used as rateId value while calling.
+   *
+   * @example "LT^rql0B^5QcM^pETcEZaBZ652v#*s"
+   */
+  id: string;
+
+  /**
+   * Exchange rate before withholding the network fee.
+   *
+   * Important. To calculate the exact amount that the user will get, you need
+   * to multiply the amount that the user wants to send to the result and deduct
+   * the value of the networkFee.
+   *
+   * @example "0.002191084078"
+   */
+  result: string;
+
+  /**
+   * Payin currency code.
+   *
+   * @example "sol"
+   */
+  from: string;
+
+  /**
+   * Payout currency code.
+   *
+   * @example "btc"
+   */
+  to: string;
+
+  /**
+   * Commission taken by the network from the amount sent to the user.
+   * For one-step exchange, displayed in pay-out currency.
+   * For two-step exchanges, displayed in BTC or in USDT.
+   *
+   * @example "0.00001909"
+   */
+  networkFee: string;
+
+  /**
+   * Maximum exchangeable amount.
+   *
+   * "700.00000000"
+   */
+  max: string;
+
+  /**
+   * Maximum payin amount for which we would be able to perform the exchange.
+   *
+   * @example "700.00000000"
+   */
+  maxFrom: string;
+
+  /**
+   * Maximum payout amount for which we would be able to perform the exchange.
+   *
+   * @example "1.57912539"
+   */
+  maxTo: string;
+
+  /**
+   * Minimum exchangeable amount.
+   *
+   * @example "0.80000000"
+   */
+  min: string;
+
+  /**
+   * Minimum payin amount for which we would be able to perform the exchange.
+   *
+   * @example "0.80000000"
+   */
+  minFrom: string;
+
+  /**
+   * Minimum payout amount for which we would be able to perform the exchange.
+   *
+   * @example "0.00180472"
+   */
+  minTo: string;
+
+  /**
+   * Unix timestamp in seconds (10 digits) representing the expiration time of the fixed rate.
+   *
+   * @example 1726538857
+   */
+  expiredAt: number;
+
+  /**
+   * Exchange fee in pay-out currency.
+   */
+  fee?: string;
+}>;
+
+/**
+ * @see https://docs.changelly.com/fix/get-fix-rate-for-amount#request
+ *
+ * @example
+ * ```sh
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getFixRateForAmount","params":{"from":"sol","to":"btc","amountFrom":"1"}}' | jq '.' -C | less -R
+ * # {
+ * #   "jsonrpc": "2.0",
+ * #   "result": [
+ * #     {
+ * #       "id": "GhNY6BJBOsjt8UlfEOHI&x0B$m6Dde",
+ * #       "from": "sol",
+ * #       "to": "btc",
+ * #       "result": "0.002191229654",
+ * #       "networkFee": "0.00001909",
+ * #       "max": "700.00000000",
+ * #       "maxFrom": "700.00000000",
+ * #       "maxTo": "1.57946710",
+ * #       "min": "0.80000000",
+ * #       "minFrom": "0.80000000",
+ * #       "minTo": "0.00180510",
+ * #       "amountFrom": "1",
+ * #       "amountTo": "0.00217213",
+ * #       "expiredAt": 1726539734
+ * #     }
+ * #   ],
+ * #   "id": "1"
+ * # }
+ * ```
+ */
+export type ChangellyApiGetFixRateForAmountParams = {
+  /**
+   * Payin currency code (in lowercase).
+   *
+   * @example "sol"
+   */
+  from: string;
+
+  /**
+   * Payout currency code (in lowercase).
+   *
+   * @example "btc"
+   */
+  to: string;
+
+  /**
+   * Amount that user is going to exchange.
+   */
+  amountFrom?: string;
+
+  /**
+   * Amount that user is going to receive.
+   */
+  amountTo?: string;
+
+  /**
+   * Escaped JSON.
+   * You can use userMetadata to include any additional parameters for customization purposes.
+   * To use this feature, please contact us at pro@changelly.com.
+   */
+  userMetadata?: string;
+};
+
+/**
+ * @see https://docs.changelly.com/fix/get-fix-rate-for-amount#response
+ */
+export type ChangellyApiGetFixRateForAmountResult = Array<{
+  /**
+   * Rate ID that can be used during 1 minute.
+   * This time should be enough for user to initiate the exchange.
+   * Expired rate id cannot be used for creation of the fixed rate transaction.
+   *
+   * id has to be stored somewhere. It will be used as rateId value while calling.
+   *
+   * @example "FHzP%N~phM2h2&zCS$JilM)tEr!8oj"
+   */
+  id: string;
+
+  /**
+   * Exchange rate before withholding the network fee.
+   *
+   * Important. To calculate the exact amount that the user will get,
+   * you need to multiply the amount that the user wants to send to
+   * the result and deduct the value of the networkFee.
+   *
+   * @example "0.002191379964"
+   */
+  result: string;
+
+  /**
+   * Payin currency code.
+   *
+   * @example "sol"
+   */
+  from: string;
+
+  /**
+   * Payout currency code.
+   *
+   * @example "btc"
+   */
+  to: string;
+
+  /**
+   * Commission taken by the network from the amount sent to the user. Displayed in pay-out currency.
+   *
+   * @example "0.00001909"
+   */
+  networkFee: string;
+
+  /**
+   * Maximum exchangeable amount.
+   *
+   * @example "700.00000000"
+   */
+  max: string;
+
+  /**
+   * Maximum payin amount for which we would be able to perform the exchange.
+   *
+   * @example "700.00000000"
+   */
+  maxFrom: string;
+
+  /**
+   * Maximum payout amount for which we would be able to perform the exchange.
+   *
+   * @example "1.57946710"
+   */
+  maxTo: string;
+
+  /**
+   * Minimum exchangeable amount.
+   *
+   * @example "0.80000000"
+   */
+  min: string;
+
+  /**
+   * Minimum payin amount for which we would be able to perform the exchange.
+   *
+   * @example "0.80000000"
+   */
+  minFrom: string;
+
+  /**
+   * Minimum payout amount for which we would be able to perform the exchange.
+   *
+   * @example "0.00180510"
+   */
+  minTo: string;
+
+  /**
+   * Amount of assets that user will exchange after creating a fixed rate transaction.
+   *
+   * @example "1"
+   */
+  amountFrom: string;
+
+  /**
+   * Fixed exchange amount that user will receive after finishing a fixed-rate transaction using current rateId.
+   *
+   * @example "0.00217228"
+   */
+  amountTo: string;
+
+  /**
+   * Unix timestamp in seconds (10 digits) representing the expiration time of the fixed rate.
+   *
+   * @example 1726539789
+   */
+  expiredAt: number;
+
+  /**
+   * Exchange fee in pay-out currency.
+   */
+  fee?: string;
+}>;
+
+/**
+ * @see https://docs.changelly.com/fix/create-fix-transaction#request
+ *
+ * @example
+ * ```sh
+ * # Replace "rateId" with "id" from "getFixRateForAmount"
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"createFixTransaction","params":{"from":"sol","to":"btc","amountFrom":"1","rateId":"l3zsI9C(1TDc5dRYOsG%fjJdu6BEuN","address":"bc1puzz9tmxawd7zdd7klfgtywrgpma3u22fz5ecxhucd4j8tygqe5ms2vdd9y","amountFrom":"1","refundAddress":"CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38"}}' | jq '.' -C | less -R
+ * # {
+ * #   "jsonrpc": "2.0",
+ * #   "result": {
+ * #     "id": "ze6rnqcnnuxxd6hc",
+ * #     "trackUrl": "https://changelly.com/track/ze6rnqcnnuxxd6hc",
+ * #     "createdAt": 1726540614000000,
+ * #     "type": "fixed",
+ * #     "status": "new",
+ * #     "payTill": "2024-09-17T02:51:54.173+00:00",
+ * #     "currencyFrom": "sol",
+ * #     "currencyTo": "btc",
+ * #     "payinAddress": "CocKqBY2yF6hXDTaM5Y5WgMUHNNjagVzAxUEMfGwUHXm",
+ * #     "amountExpectedFrom": "1",
+ * #     "payoutAddress": "bc1puzz9tmxawd7zdd7klfgtywrgpma3u22fz5ecxhucd4j8tygqe5ms2vdd9y",
+ * #     "refundAddress": "CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38",
+ * #     "amountExpectedTo": "0.00219147",
+ * #     "networkFee": "0.00001909"
+ * #   },
+ * #   "id": "1"
+ * # }
+ * ```
+ */
+export type ChangellyApiCreateFixedRateTransactionParams = {
+  /**
+   * Payin currency code (in lowercase).
+   *
+   * @example "btc"
+   */
+  from: string;
+
+  /**
+   * Payout currency code (in lowercase).
+   *
+   * @example "sol"
+   */
+  to: string;
+
+  /**
+   * Rate ID that you get from getFixRate/getFixRateForAmount requests.
+   *
+   * @see https://docs.changelly.com/fix/get-fix-rate
+   * @see https://docs.changelly.com/fix/get-fix-rate-for-amount
+   *
+   * @example "FHzP%N~phM2h2&zCS$JilM)tEr!8oj"
+   */
+  rateId: string;
+
+  /**
+   * Recipient address.
+   *
+   * @example "CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38"
+   */
+  address: string;
+
+  /**
+   * Amount of currency that user is going to send.
+   *
+   * @example "1"
+   */
+  amountFrom?: string;
+
+  /**
+   * Amount user wants to receive.
+   */
+  amountTo?: string;
+
+  /**
+   * Additional ID for address for currencies that use additional ID for transaction processing.
+   */
+  extraId?: string;
+
+  /**
+   * Address of the wallet to refund in case of any technical issues during the exchange.
+   * The currency of the wallet must match with the from currency.
+   *
+   * @example "CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38"
+   */
+  refundAddress: string;
+
+  /**
+   * extraId for refundAddress.
+   */
+  refundExtraId?: string;
+
+  /**
+   * Address of the wallet from which the user will send payin.
+   */
+  fromAddress?: string;
+
+  /**
+   * extraId for fromAddress.
+   */
+  fromExtraId?: string;
+
+  /**
+   * subaccountId from createSubaccount.
+   *
+   * @see https://docs.changelly.com/subaccounts/subaccount
+   */
+  subaccountId?: string;
+
+  /**
+   * Escaped JSON.
+   * You can use userMetadata to include any additional parameters for customization purposes.
+   * To use this feature, please contact us at pro@changelly.com.
+   */
+  userMetadata?: string;
+};
+
+/**
+ * @see https://docs.changelly.com/fix/create-fix-transaction#response
+ */
+export type ChangellyApiCreateFixedRateTransactionResult = {
+  /**
+   * Not documented
+   *
+   * Contains a URL that you can visit to follow the transaction
+   *
+   * @example "https://changelly.com/track/ze6rnqcnnuxxd6hc"
+   */
+  trackUrl: string;
+
+  /**
+   * Transaction ID. Could be used in getStatus method.
+   *
+   * @see https://docs.changelly.com/info/get-status
+   *
+   * @example "ze6rnqcnnuxxd6hc"
+   */
+  id: string;
+
+  /**
+   * Type of transaction. Always fixed in this method.
+   *
+   * @example "fixed"
+   */
+  type: string;
+
+  /**
+   * Address for a user to send coins to.
+   *
+   * @example "CocKqBY2yF6hXDTaM5Y5WgMUHNNjagVzAxUEMfGwUHXm"
+   */
+  payinAddress: string;
+
+  /**
+   * Extra ID for payinAddress in case it is required.
+   * Note: If the payinExtraId parameter is returned in the response and is not null,
+   * it is required for user to send the funds to the payinAddress specifying extraId.
+   * Otherwise, the transactions will not be processed and the user will need to get a
+   * refund through technical support.
+   */
+  payinExtraId?: string;
+
+  /**
+   * Address where the exchange result will be sent to.
+   *
+   * @example "bc1puzz9tmxawd7zdd7klfgtywrgpma3u22fz5ecxhucd4j8tygqe5ms2vdd9y"
+   */
+  payoutAddress: string;
+
+  /**
+   * Extra ID for payoutAddress in case it is required.
+   */
+  payoutExtraId?: string;
+
+  /**
+   * Address of the wallet to refund in case of any technical issues during the exchange.
+   * The currency of the wallet must match with the from currency.
+   *
+   * @example "CMGoYEKM8kSXwN9HzYiwRiZRXoMtEAQ98ZiPE9y67T38"
+   */
+  refundAddress: string;
+
+  /**
+   * Extra ID for refundAddress.
+   */
+  refundExtraId?: string;
+
+  /**
+   * The amountFrom value from createFixTransaction request.
+   *
+   * @example "1"
+   */
+  amountExpectedFrom: number;
+
+  /**
+   * The amountTo value from getFixRateForAmount response.
+   * This is the estimated payout amount of currency before withholding the network fee.
+   *
+   * @see https://docs.changelly.com/fix/get-fix-rate-for-amount
+   *
+   * @example "0.00219147"
+   */
+  amountExpectedTo: string;
+
+  /**
+   * Transaction status.
+   * Will always be new when transaction is created.
+   * If you reference the same transaction using the getStatus or getTransactions method,
+   * you'll get the waiting status as an equivalent to new.
+   *
+   * @example "new"
+   */
+  status: string;
+
+  /**
+   * Indicates time until which user needs to make the payment.
+   *
+   * @example "2024-09-17T02:51:54.173+00:00"
+   */
+  payTill: string;
+
+  /**
+   * Payout currency code.
+   *
+   * @example "btc"
+   */
+  currencyTo: string;
+
+  /**
+   * Payin currency code.
+   *
+   * @example "sol"
+   */
+  currencyFrom: string;
+
+  /**
+   * Time in timestamp format (microseconds) when the transaction was created.
+   *
+   * @example 1726540614000000
+   */
+  createdAt: number;
+
+  /**
+   * Commission taken by the network from the amount sent to the user. Displayed in payout currency.
+   *
+   * @example "0.00001909"
+   */
+  networkFee: string;
+};
+
+/**
+ * @see https://docs.changelly.com/info/get-status#request
+ *
+ * @example
+ * ```sh
+ * # Replace "id" with "id" from "createFixTransaction"
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getStatus","params":{"id":"ze6rnqcnnuxxd6hc"}}' | jq '.' -C | less -R
+ * # {
+ * #   "jsonrpc": "2.0",
+ * #   "result": "waiting",
+ * #   "id": "1"
+ * # }
+ * ```
+ */
+
+export type ChangellyApiGetStatusParams = {
+  /**
+   * Transaction ID.
+   *
+   * @example "ze6rnqcnnuxxd6hc"
+   */
+  id: string;
+};
+
+/**
+ * @see https://docs.changelly.com/info/get-status#response
+ *
+ * Transaction status.
+ *
+ * @example "waiting"
+ */
+export type ChangellyApiGetStatusResult = string;

--- a/packages/swap/src/providers/jupiter/types.ts
+++ b/packages/swap/src/providers/jupiter/types.ts
@@ -121,10 +121,19 @@ export type JupiterSwapResponse = {
   computeUnitLimit?: number;
   prioritizationType?: {
     computeBudget?: {
-      microLamports: 71428;
-      estimatedMicroLamports: 142856;
+      /** @example 71428 */
+      microLamports: number;
+      /** @example 142856 */
+      estimatedMicroLamports: number;
     };
   };
-  dynamicSlippageReport: null;
+  // TODO: Narrow down
+  dynamicSlippageReport: null | {
+    slippageBps?: null | string | number;
+    otherAmount?: null | string | number;
+    simulatedIncurredSlippageBps?: null | string | number;
+    amplificationRatio?: null | string | number;
+  };
+  // TODO: Type
   simulationError: null;
 };

--- a/packages/swap/src/providers/jupiter/types.ts
+++ b/packages/swap/src/providers/jupiter/types.ts
@@ -1,0 +1,130 @@
+/**
+ * curl -sL https://tokens.jup.ag/tokens?tags=verified | jq -C | less -N
+ */
+export type JupiterTokenInfo = {
+  address: string;
+  name: string;
+  symbol: string;
+  decimals: string;
+};
+
+// Jupiter API Quote
+
+/**
+ * see https://station.jup.ag/api-v6/get-quote
+ *
+ * ```sh
+ * curl -sL -H 'Accept: application/json' 'https://quote-api.jup.ag/v6/quote?inputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&outputMint=So11111111111111111111111111111111111111112&amount=5'
+ * ```
+ */
+export type JupiterQuoteResponse = {
+  /** @example "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" */
+  inputMint: string;
+  /** @example "5" */
+  inAmount: string;
+  /** @example "So11111111111111111111111111111111111111112" */
+  outputMint: string;
+  /** @example "35" */
+  outAmount: string;
+  /** @example "35" */
+  otherAmountThreshold: string;
+  /** @example "ExactIn" */
+  swapMode: string;
+  /** @example 50 */
+  slippageBps: number;
+  /** @example {"amount":"1","feeBps":1} */
+  platformFee: null | {
+    /** @example '1' */
+    amount: string;
+    /** @example 1 */
+    feeBps: number;
+  };
+  /** @example "0" */
+  priceImpactPct: string;
+  routePlan: {
+    swapInfo: {
+      /** @example "5URw47pYHN9heEQFKtUFeHzTskHwN78bBvKefV5C98fe" */
+      ammKey: string;
+      /** @example "Oasis" */
+      label: string;
+      /** @example "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" */
+      inputMint: string;
+      /** @example "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" */
+      outputMint: string;
+      /** @example  "5" */
+      inAmount: string;
+      /** @e xample "28679" */
+      outAmount: string;
+      /** @exampl e "115" */
+      feeAmount: string;
+      /** @example "DezXAZ8z7Pn rnRJjz3wXBoRgixCa6xjnB7YaB1pPB263" */
+      feeMint: string;
+    };
+    /** @example 100  */
+    percent: number;
+  }[];
+  /** @example 284606533 */
+  contextSlot: number;
+  /** @example 0.743937514 */
+  timeTaken: number;
+};
+
+// Jupiter API Swap
+
+/**
+ * @see https://station.jup.ag/api-v6/post-swap
+ *
+ * HTTP request JSON body to request a Swap transaction for a given quote
+ */
+export type JupiterSwapParams = {
+  userPublicKey: string;
+  /** Default: true */
+  wrapAndUnwrapSol?: boolean;
+  useSharedAccounts?: boolean;
+  /** Referral address */
+  feeAccount?: string;
+  /** Public key used to track transactions */
+  trackingAccount?: string;
+  /** Integer */
+  computeUnitPriceMicroLamports?: number;
+  prioritizationFeeLamports?: number;
+  /** Default: false */
+  asLegacyTransaction?: boolean;
+  /** Default: false */
+  useTokenLedger?: boolean;
+  /** Public key of key of token receiver. Default: user's own ATA. */
+  destinationTokenAccount?: string;
+  /**
+   * Simulate the swap to get the compute units (like gas in the EVM) &
+   * set in ComputeBudget's compute unit limit.
+   *
+   * Default: false
+   */
+  dynamicComputeUnitLimit?: boolean;
+  /** Do not do RPC calls to check on user's account. Default: false. */
+  skipUserAccountRpcCalls?: boolean;
+  /** Response from the Jupiter API quote endpoint */
+  quoteResponse: JupiterQuoteResponse;
+};
+
+/**
+ * @see https://station.jup.ag/api-v6/post-swap
+ */
+export type JupiterSwapResponse = {
+  /** Base64 encoded versioned transaction */
+  swapTransaction: string;
+  /** @example 265642441 */
+  lastValidBlockHeight: number;
+  /** @example 99999 */
+  prioritizationFeeLamports?: number;
+  /** @example 1400000 */
+  computeUnitLimit?: number;
+  prioritizationType?: {
+    computeBudget?: {
+      microLamports: 71428;
+      estimatedMicroLamports: 142856;
+    };
+  };
+  dynamicSlippageReport: null;
+  simulationError: null;
+};

--- a/packages/swap/src/types/index.ts
+++ b/packages/swap/src/types/index.ts
@@ -165,8 +165,11 @@ export interface SolanaTransaction {
   from: string;
   /** TODO: document what this is for, I think it's just for UI */
   to: string;
+  kind: "legacy" | "versioned";
   /** base64 serialized unsigned solana transaction */
   serialized: string;
+  /** If the transaction is signed (by a third party like Rango) then we can't change it's recentblock hash */
+  signed: boolean;
   type: TransactionType.solana;
 }
 

--- a/packages/swap/src/utils/solana.ts
+++ b/packages/swap/src/utils/solana.ts
@@ -1,10 +1,53 @@
 import {
   AccountMeta,
+  AddressLookupTableAccount,
   ComputeBudgetInstruction,
   ComputeBudgetProgram,
+  Connection,
+  PublicKey,
+  SystemProgram,
   TransactionInstruction,
+  TransactionMessage,
   VersionedTransaction,
 } from "@solana/web3.js";
+
+/**
+ * Address of the SPL Token program
+ *
+ * @see https://solscan.io/account/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
+ */
+export const TOKEN_PROGRAM_ID = new PublicKey(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+);
+
+/**
+ * Address of the SPL Token 2022 program
+ *
+ * @see https://solscan.io/account/TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+ */
+export const TOKEN_2022_PROGRAM_ID = new PublicKey(
+  "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb"
+);
+
+/**
+ * Address of the SPL Associated Token Account program
+ *
+ * (Creates Associated Token Accounts (ATA))
+ *
+ * @see https://solscan.io/account/ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
+ */
+export const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey(
+  "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL"
+);
+
+export const SPL_TOKEN_ATA_ACCOUNT_SIZE_BYTES = 165;
+
+/**
+ * Wrapped SOL address
+ * @see https://solscan.io/token/So11111111111111111111111111111111111111112
+ */
+export const WRAPPED_SOL_ADDRESS =
+  "So11111111111111111111111111111111111111112";
 
 /**
  * @see https://solana.com/docs/core/fees#prioritization-fees
@@ -18,6 +61,8 @@ export function extractComputeBudget(
   tx: VersionedTransaction
 ): undefined | number {
   // extract the compute budget
+
+  /** Compute units */
   let computeBudget: undefined | number;
 
   // eslint-disable-next-line no-restricted-syntax, no-labels
@@ -62,6 +107,333 @@ export function extractComputeBudget(
     }
   }
 
-  // (default of 200_000 from Google)
-  return computeBudget ?? 200_000;
+  /**
+   * @see https://solanacookbook.com/references/basic-transactions.html#how-to-change-compute-budget-fee-priority-for-a-transaction
+   *
+   * Default is minimum of 14m and 200_000 * instruction count
+   */
+  return (
+    computeBudget ??
+    Math.min(1_400_000, 200_000 * tx.message.compiledInstructions.length)
+  );
+}
+
+/**
+ * Insert new instructions at the start of a transaction, after compute budget and compute limit instructions
+ */
+export async function insertInstructionsAtStartOfTransaction(
+  conn: Connection,
+  tx: VersionedTransaction,
+  instructions: TransactionInstruction[]
+): Promise<VersionedTransaction> {
+  if (instructions.length === 0) return tx;
+
+  // Now we need to:
+  // 1. Decompile the transaction
+  // 2. Put our instructions in it
+  // 3. Recompile it
+
+  // Request lookup accounts so that we can decompile the message
+  //
+  // Lookup accounts store arrays of addresses. These accounts let compiled transaction messages reference indexes
+  // in the lookup account rather than by the pubkey, saving lots of space (~4 byte integer index vs 32 byte pubkey).
+  //
+  // To decompile a message we first need all the lookup accounts that it includes so that we can get the
+  // the addresses that our message needs.
+  //
+  // We can also use the lookup accounts when re-compiling the transaction.
+  const lookupAccountsCount = tx.message.addressTableLookups.length;
+  const addressLookupTableAccounts: AddressLookupTableAccount[] = new Array(
+    lookupAccountsCount
+  );
+
+  for (let i = 0; i < lookupAccountsCount; i++) {
+    const lookup = tx.message.addressTableLookups[i];
+    const result = await conn.getAddressLookupTable(lookup.accountKey);
+    const addressLookupTableAccount = result.value;
+    if (addressLookupTableAccount == null)
+      throw new Error(
+        `Failed to get address lookup table for ${lookup.accountKey}`
+      );
+    // debug(
+    //   "insertInstructionsAtStartOfTransaction",
+    //   `Fetching lookup account ${i + 1}. ${lookup.accountKey.toBase58()}`
+    // );
+    addressLookupTableAccounts[i] = addressLookupTableAccount;
+  }
+
+  // Decompile the transaction message so we can modify it
+  const decompiledTransactionMessage = TransactionMessage.decompile(
+    tx.message,
+    { addressLookupTableAccounts }
+  );
+
+  // Insert our instruction to create an account directly after compute budget
+  // program instructions that compute limits and priority fees
+  const computeBudgetProgramAddr = ComputeBudgetProgram.programId.toBase58();
+  let inserted = false;
+  // eslint-disable-next-line no-restricted-syntax, no-labels
+  instructionLoop: for (
+    let i = 0, len = decompiledTransactionMessage.instructions.length;
+    i < len;
+    i++
+  ) {
+    // As soon as we hit a non compute budget program, insert our instruction to create the account
+    const existingInstruction = decompiledTransactionMessage.instructions[i];
+    switch (existingInstruction.programId.toBase58()) {
+      case computeBudgetProgramAddr:
+        // do nothing
+        break;
+      default: {
+        // insert our instruction here & continue
+        // debug(
+        //   "insertInstructionsAtStartOfTransaction",
+        //   `Inserting instruction to create an ATA account for Jupiter referrer with mint at instruction index ${i}`
+        // );
+        inserted = true;
+        decompiledTransactionMessage.instructions.splice(i, 0, ...instructions);
+        // eslint-disable-next-line no-labels
+        break instructionLoop;
+      }
+    }
+  }
+
+  if (!inserted) {
+    // If there were no compute budget instructions then just add it at the start
+    // debug(
+    //   "insertInstructionsAtStartOfTransaction",
+    //   `Inserting instruction to create an ATA account for Jupiter referrer with mint at start of instructions`
+    // );
+    for (let len = instructions.length - 1, i = len - 1; i >= 0; i--) {
+      decompiledTransactionMessage.instructions.unshift(instructions[i]);
+    }
+  }
+
+  // Switch to using this modified transaction
+  // debug("insertInstructionsAtStartOfTransaction", `Re-compiling transaction`);
+  const modifiedTx = new VersionedTransaction(
+    decompiledTransactionMessage.compileToV0Message(addressLookupTableAccounts)
+  );
+
+  return modifiedTx;
+}
+
+/**
+ * Get the SPL token program that owns (/created) the given mint (token). Either the SPL token program
+ * or the 2022 SPL token program
+ *
+ * @returns   Pubkey of the SPL token token owner program
+ * @throws    If the account does not exist or if it's not owned by one of the SPL token programs
+ */
+export async function getTokenProgramOfMint(
+  conn: Connection,
+  mint: PublicKey
+): Promise<PublicKey> {
+  // debug("getTokenProgramOfMint", `Checking mint account of ${mint.toBase58()}`);
+  const srcMintAcc = await conn.getAccountInfo(mint);
+
+  if (srcMintAcc == null) {
+    throw new Error(
+      `There is no SPL token account at address ${mint.toBase58()}`
+    );
+  }
+
+  switch (srcMintAcc.owner.toBase58()) {
+    case TOKEN_PROGRAM_ID.toBase58():
+    case TOKEN_2022_PROGRAM_ID.toBase58():
+      return srcMintAcc.owner;
+    default:
+      throw new Error(
+        `Mint address is not a valid SPL token, must either have owner` +
+          ` TOKEN_PROGRAM_ID (${TOKEN_PROGRAM_ID.toBase58()})` +
+          ` or TOKEN_2022_PROGRAM_ID (${TOKEN_2022_PROGRAM_ID.toBase58()})`
+      );
+  }
+}
+
+/**
+ * Get the SPL token ATA pubkey for a wallet with a mint
+ */
+export function getSPLAssociatedTokenAccountPubkey(
+  wallet: PublicKey,
+  mint: PublicKey,
+  /** Either the SPL token program or the 2022 SPL token program */
+  tokenProgramId: PublicKey
+): PublicKey {
+  const SEED = [wallet.toBuffer(), tokenProgramId.toBuffer(), mint.toBuffer()];
+  const [associatedTokenAddress] = PublicKey.findProgramAddressSync(
+    SEED,
+    ASSOCIATED_TOKEN_PROGRAM_ID
+  );
+  return associatedTokenAddress;
+}
+
+/**
+ * Construct a CreateAssociatedTokenAccountIdempotent instruction
+ *
+ * @param payer                    Payer of the initialization fees
+ * @param associatedToken          New associated token account
+ * @param owner                    Owner of the new account
+ * @param mint                     Token mint account
+ * @param programId                SPL Token program account
+ * @param associatedTokenProgramId SPL Associated Token program account
+ *
+ * @return Instruction to add to a transaction
+ */
+export function createAssociatedTokenAccountIdempotentInstruction(
+  payer: PublicKey,
+  associatedToken: PublicKey,
+  owner: PublicKey,
+  mint: PublicKey,
+  programId = TOKEN_PROGRAM_ID,
+  associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+): TransactionInstruction {
+  // eslint-disable-next-line no-use-before-define
+  return buildAssociatedTokenAccountInstruction(
+    payer,
+    associatedToken,
+    owner,
+    mint,
+    Buffer.from([1]),
+    programId,
+    associatedTokenProgramId
+  );
+}
+
+export function buildAssociatedTokenAccountInstruction(
+  payer: PublicKey,
+  associatedToken: PublicKey,
+  owner: PublicKey,
+  mint: PublicKey,
+  instructionData: Buffer,
+  programId = TOKEN_PROGRAM_ID,
+  associatedTokenProgramId = ASSOCIATED_TOKEN_PROGRAM_ID
+): TransactionInstruction {
+  const keys = [
+    { pubkey: payer, isSigner: true, isWritable: true },
+    { pubkey: associatedToken, isSigner: false, isWritable: true },
+    { pubkey: owner, isSigner: false, isWritable: false },
+    { pubkey: mint, isSigner: false, isWritable: false },
+    { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+    { pubkey: programId, isSigner: false, isWritable: false },
+  ];
+
+  return new TransactionInstruction({
+    keys,
+    programId: associatedTokenProgramId,
+    data: instructionData,
+  });
+}
+
+/**
+ * Create a transaction instruction that creates the given ATA for the owner and mint.
+ *
+ * Does nothing if the mint already exists.
+ *
+ * @see https://github.com/solana-labs/solana-program-library/blob/e018a30e751e759e62e17ad01864d4c57d090c26/token/js/src/instructions/associatedTokenAccount.ts#L49
+ * @see https://github.com/solana-labs/solana-program-library/blob/e018a30e751e759e62e17ad01864d4c57d090c26/token/js/src/instructions/associatedTokenAccount.ts#L100
+ */
+export function getCreateAssociatedTokenAccountIdempotentInstruction(params: {
+  /** Payer of initialization / rent fees */
+  payerPubkey: PublicKey;
+  /** Address of the Associated Token Account of `ownerPubkey` with `mintPubkey` @see `getSPLAssociatedTokenAccountPubkey` */
+  ataPubkey: PublicKey;
+  /** Owner of the new SPL Associated Token Account */
+  ownerPubkey: PublicKey;
+  /**
+   * SPL token address
+   *
+   * @example new PublicKey('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') // USDC
+   * @example new PublicKey('Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB') // USDT
+   * @example new PublicKey('So11111111111111111111111111111111111111112') // Wrapped SOL
+   *
+   * USDC @see https://solscan.io/token/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v
+   * USDT @see https://solscan.io/token/Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB
+   * Wrapped SOL @see https://solscan.io/token/So11111111111111111111111111111111111111112
+   */
+  mintPubkey: PublicKey;
+  /**
+   * @example new PublicKey('11111111111111111111111111111111')
+   */
+  systemProgramId: PublicKey;
+  /**
+   * SPL Token Program or 2022 SPL token program
+   *
+   * @example new PublicKey('TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA')
+   * @example new PublicKey('TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb')
+   */
+  tokenProgramId: PublicKey;
+  /**
+   * SPL Associated Token Program account,
+   *
+   * @example new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL')
+   *
+   * @see https://solscan.io/account/ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL
+   */
+  associatedTokenProgramId: PublicKey;
+}): TransactionInstruction {
+  const {
+    payerPubkey,
+    ataPubkey,
+    ownerPubkey,
+    mintPubkey,
+    systemProgramId,
+    tokenProgramId,
+    associatedTokenProgramId,
+  } = params;
+
+  const keys = [
+    { pubkey: payerPubkey, isSigner: true, isWritable: true },
+    { pubkey: ataPubkey, isSigner: false, isWritable: true },
+    { pubkey: ownerPubkey, isSigner: false, isWritable: false },
+    { pubkey: mintPubkey, isSigner: false, isWritable: false },
+    { pubkey: systemProgramId, isSigner: false, isWritable: false },
+    { pubkey: tokenProgramId, isSigner: false, isWritable: false },
+  ];
+
+  return new TransactionInstruction({
+    keys,
+    programId: associatedTokenProgramId,
+    data: Buffer.from([1]),
+  });
+}
+
+/**
+ * Is the address a valid Solana address? (32 byte base58 string)
+ *
+ * @param address   hopefully 32 byte base58 string
+ * @returns         true if `address` is a 32 byte base58 string
+ */
+export function isValidSolanaAddress(address: string): boolean {
+  try {
+    // eslint-disable-next-line no-new
+    new PublicKey(address);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+
+export async function isValidSolanaAddressAsync(
+  address: string
+): Promise<boolean> {
+  return isValidSolanaAddress(address);
+}
+
+/**
+ * Does the Solana account exist?
+ *
+ * Checks if the account has been created
+ *
+ * @param conn      Solana connection
+ * @param address   Address to check
+ * @returns         `true` if there's an account at `address`
+ */
+export async function solAccountExists(
+  conn: Connection,
+  address: PublicKey
+): Promise<boolean> {
+  const account = await conn.getAccountInfo(address, "max");
+  const exists = account != null;
+  return exists;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,6 +3286,7 @@ __metadata:
   dependencies:
     "@enkryptcom/types": "workspace:^"
     "@enkryptcom/utils": "workspace:^"
+    "@solana/spl-token": ^0.4.8
     "@solana/web3.js": ^1.95.3
     "@types/chai": ^4.3.19
     "@types/mocha": ^10.0.7


### PR DESCRIPTION
- Almost finish adding support for Changelly on Solana, waiting for response from Changelly team
- Finish adding (untested) support for Rango on Solana
- Added support for third-party-signed Solana swap transactions (required by Rango) and Legacy transactions (also Rango)
- Added a whole lot of extra debug and warning logs for Changelly and Rango
- Fix some issues with the Changelly API
- Add types for all relevant Changelly API endpoints and documentation links
- Add `@solana/spl-token` as a dependency

Only swap of native SOL to token on other network via Changelly has been tested.