### PR TITLE
Fix failing swap tests

### DIFF
--- a/packages/swap/src/configs.ts
+++ b/packages/swap/src/configs.ts
@@ -101,7 +101,7 @@ const TOKEN_LISTS: {
 
 /**
  * ```sh
- * curl -sL https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/changelly.json | jq '.' -C | less -R
+ * curl -sL https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/changelly.json | jq . -C | less -R
  * ```
  */
 const CHANGELLY_LIST =
@@ -109,7 +109,7 @@ const CHANGELLY_LIST =
 
 /**
  * ```sh
- * curl -sL https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/top-tokens.json | jq '.' -C | less -R
+ * curl -sL https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/top-tokens.json | jq . -C | less -R
  * ```
  */
 const TOP_TOKEN_INFO_LIST =

--- a/packages/swap/src/providers/changelly/index.ts
+++ b/packages/swap/src/providers/changelly/index.ts
@@ -473,7 +473,17 @@ class Changelly extends ProviderClass {
     else if (quoteRequestAmount.gt(minMax.maximumFrom))
       quoteRequestAmount = minMax.maximumFrom;
 
-    if (quoteRequestAmount.toString() === "0") return null;
+    if (quoteRequestAmount.toString() === "0") {
+      debug(
+        "getQuote",
+        `No swap: Quote request amount is zero` +
+          `  fromToken=${options.fromToken.symbol}` +
+          `  toToken=${options.toToken.symbol}` +
+          `  minimumFrom=${minMax.minimumFrom.toString()}` +
+          `  maximumFrom=${minMax.maximumFrom.toString()}`
+      );
+      return null;
+    }
 
     debug("getQuote", `Requesting changelly swap...`);
 

--- a/packages/swap/src/providers/changelly/types.ts
+++ b/packages/swap/src/providers/changelly/types.ts
@@ -108,7 +108,8 @@ export type ChangellyApiValidateAddressResult = {
  *
  * @example
  * ```sh
- * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getFixRate","params":{"from":"sol","to":"btc"}}' | jq '.' -C | less -R
+ * # SOL to BTC
+ * curl -sL https://partners.mewapi.io/changelly-v2 -X POST -H Accept:application/json -H Content-Type:application/json --data '{"id":"1","jsonrpc":"2.0","method":"getFixRate","params":{"from":"sol","to":"btc"}}' | jq . -C | less -R
  * # {
  * #   "jsonrpc": "2.0",
  * #   "result": [
@@ -129,6 +130,9 @@ export type ChangellyApiValidateAddressResult = {
  * #   ],
  * #   "id": "1"
  * # }
+ *
+ * # DAI to USDC
+ * curl https://partners.mewapi.io/changelly-v2 -sL -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' --data '{"jsonrpc":"2.0","id":"1","method":"getFixRate","params":{"from":"dai","to":"usdc"}}' | jq . -C | less -R
  * ````
  */
 export type ChangellyApiGetFixRateParams = {

--- a/packages/swap/tests/changelly.test.ts
+++ b/packages/swap/tests/changelly.test.ts
@@ -10,9 +10,9 @@ import {
   WalletIdentifier,
 } from "../src/types";
 import {
-  fromToken,
+  fromTokenUSDT,
   toToken,
-  amount,
+  amountUSDT,
   fromAddress,
   toAddress,
   nodeURL as ethNodeURL,
@@ -29,9 +29,9 @@ describe("Changelly Provider", () => {
     await init;
     const quote = await changelly.getQuote(
       {
-        amount,
+        amount: amountUSDT,
         fromAddress,
-        fromToken,
+        fromToken: fromTokenUSDT,
         toToken,
         toAddress,
       },
@@ -42,7 +42,7 @@ describe("Changelly Provider", () => {
     expect(quote?.quote.meta.walletIdentifier).to.be.eq(
       WalletIdentifier.enkrypt
     );
-    expect(quote?.fromTokenAmount.gte(amount)).to.be.eq(true);
+    expect(quote?.fromTokenAmount.gte(amountUSDT)).to.be.eq(true);
     expect(quote?.toTokenAmount.gtn(0)).to.be.eq(true);
     const swap = await changelly.getSwap(quote!.quote);
 

--- a/packages/swap/tests/fixtures/mainnet/configs.ts
+++ b/packages/swap/tests/fixtures/mainnet/configs.ts
@@ -2,7 +2,8 @@ import { NetworkNames } from "@enkryptcom/types";
 import { isAddress, toBN } from "web3-utils";
 import { NetworkType, TokenType, TokenTypeTo } from "../../../src/types";
 
-const amount = toBN("100000000000000000000");
+const amount = toBN("100000000000000000000"); // DAI, $100, 18 decimals
+const amountUSDT = toBN("1000000000"); // USDT, $1,000, 6 decimals
 
 const fromAddress = "0x6B175474E89094C44Da98b954EedeAC495271d0F";
 const toAddress = "0x255d4D554325568A2e628A1E93120EbA1157C07e";
@@ -29,6 +30,18 @@ const fromToken: TokenType = {
   symbol: "DAI",
   rank: 18,
   cgId: "dai",
+  type: NetworkType.EVM,
+};
+
+const fromTokenUSDT: TokenType = {
+  address: "0xdac17f958d2ee523a2206206994597c13d831ec7",
+  decimals: 6,
+  logoURI:
+    "https://assets.coingecko.com/coins/images/325/standard/Tether.png?1696501661",
+  name: "Tether",
+  symbol: "USDT",
+  rank: 18,
+  cgId: "tether",
   type: NetworkType.EVM,
 };
 
@@ -77,10 +90,12 @@ const toToken: TokenTypeTo = {
 
 export {
   fromToken,
+  fromTokenUSDT,
   toToken,
   toTokenWETH,
   fromTokenWBTC,
   amount,
+  amountUSDT,
   fromAddress,
   toAddress,
   nodeURL,

--- a/packages/swap/tests/swap.test.ts
+++ b/packages/swap/tests/swap.test.ts
@@ -8,9 +8,11 @@ import {
   WalletIdentifier,
 } from "../src/types";
 import {
-  fromToken,
+  // fromToken,
+  fromTokenUSDT,
   toToken,
-  amount,
+  // amount,
+  amountUSDT,
   fromAddress,
   toAddress,
   nodeURL,
@@ -55,9 +57,9 @@ describe("Swap", () => {
   it("it should get quote and swap for different destination", async () => {
     await enkryptSwap.initPromise;
     const quotes = await enkryptSwap.getQuotes({
-      amount,
+      amount: amountUSDT,
       fromAddress,
-      fromToken,
+      fromToken: fromTokenUSDT,
       toToken,
       toAddress,
     });
@@ -81,7 +83,9 @@ describe("Swap", () => {
     expect(oneInceQuote!.provider).to.be.eq(ProviderName.oneInch);
     expect(paraswapQuote!.provider).to.be.eq(ProviderName.paraswap);
     const swapOneInch = await enkryptSwap.getSwap(oneInceQuote!.quote);
-    expect(swapOneInch?.fromTokenAmount.toString()).to.be.eq(amount.toString());
+    expect(swapOneInch?.fromTokenAmount.toString()).to.be.eq(
+      amountUSDT.toString()
+    );
     expect(swapOneInch?.transactions.length).to.be.eq(2);
     const swapChangelly = await enkryptSwap.getSwap(changellyQuote!.quote);
     if (swapChangelly) expect(swapChangelly?.transactions.length).to.be.eq(1);
@@ -90,9 +94,9 @@ describe("Swap", () => {
   it("it should get quote and swap for same destination", async () => {
     await enkryptSwap.initPromise;
     const quotes = await enkryptSwap.getQuotes({
-      amount,
+      amount: amountUSDT,
       fromAddress,
-      fromToken,
+      fromToken: fromTokenUSDT,
       toToken,
       toAddress: fromAddress,
     });


### PR DESCRIPTION
Changelly started returning zero maximum amount for swap between dai and usdc, breaking the tests.

```sh
curl https://partners.mewapi.io/changelly-v2 -sL \
  -X POST \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  --data '{
    "jsonrpc": "2.0",
    "id": "1",
    "method": "getFixRate",
    "params": {
      "from": "dai",
      "to": "usdc"
    }
  }' | jq .

# {
#   "jsonrpc": "2.0",
#   "result": [
#     {
#       "id": "...",
#       "from": "dai",
#       "to": "usdc",
#       "result": "0.000000000000",
#       "networkFee": "2.645967",
#       "max": "0",
#       "maxFrom": "0",
#       "maxTo": "0",
#       "min": "0",
#       "minFrom": "0",
#       "minTo": "0",
#       "expiredAt": 1729131334
#     }
#   ],
#   "id": "1"
# }
```

I switched Changelly to use usdt to usdc instead wherein Changelly returns a greater-than-zero maximum amount, fixing the tests.

```sh
curl https://partners.mewapi.io/changelly-v2 -sL \
  -X POST \
  -H 'Accept: application/json' \
  -H 'Content-Type: application/json' \
  --data '{
    "jsonrpc": "2.0",
    "id": "1",
    "method": "getFixRate",
    "params": {
      "from": "usdt20",
      "to": "usdc"
    }
  }' | jq .

# {
#   "jsonrpc": "2.0",
#   "result": [
#     {
#       "id": "...",
#       "from": "usdt20",
#       "to": "usdc",
#       "result": "0.978823121892",
#       "networkFee": "3.034319",
#       "max": "160016.000000",
#       "maxFrom": "160016.000000",
#       "maxTo": "160000.000000",
#       "min": "95.769576",
#       "minFrom": "95.769576",
#       "minTo": "95.760000",
#       "expiredAt": 1729131374
#     }
#   ],
#   "id": "1"
# }
```
