### PR TITLE
feat: enable changelly on solana

### DIFF
--- a/packages/extension/src/ui/action/views/swap/libs/solana-gasvals.ts
+++ b/packages/extension/src/ui/action/views/swap/libs/solana-gasvals.ts
@@ -11,23 +11,71 @@ import {
 import BigNumber from "bignumber.js";
 import { toBN } from "web3-utils";
 
+type TaggedLegacyTransaction = {
+  kind: "legacy";
+  instance: SolanaLegacyTransaction;
+  hasThirdPartySignatures: boolean;
+};
+
+type TaggedVersionedTransaction = {
+  kind: "versioned";
+  instance: SolanaVersionedTransaction;
+  hasThirdPartySignatures: boolean;
+};
+
+type TaggedTransaction = TaggedLegacyTransaction | TaggedVersionedTransaction;
+
+function getTxBlockHash(tx: TaggedTransaction): undefined | string {
+  let recentBlockHash: undefined | string;
+  switch (tx.kind) {
+    case "legacy":
+      recentBlockHash = tx.instance.recentBlockhash;
+      break;
+    case "versioned":
+      recentBlockHash = tx.instance.message.recentBlockhash;
+      break;
+    default:
+      tx satisfies never;
+      throw new Error(`Unexpected Solana transaction kind ${(tx as any).kind}`);
+  }
+  return recentBlockHash;
+}
+
+function setTxBlockHash(tx: TaggedTransaction, blockHash: string): void {
+  switch (tx.kind) {
+    case "legacy":
+      tx.instance.recentBlockhash = blockHash;
+      break;
+    case "versioned":
+      tx.instance.message.recentBlockhash = blockHash;
+      break;
+    default:
+      tx satisfies never;
+      throw new Error(`Unexpected Solana transaction kind ${(tx as any).kind}`);
+  }
+}
+
+function getTxMessage(tx: TaggedTransaction): Message | VersionedMessage {
+  let msg: Message | VersionedMessage;
+  switch (tx.kind) {
+    case "legacy":
+      msg = tx.instance.compileMessage();
+      break;
+    case "versioned":
+      msg = tx.instance.message;
+      break;
+    default:
+      throw new Error(`Unexpected Solana transaction kind ${(tx as any).kind}`);
+  }
+  return msg;
+}
+
 /**
  * Mutably updates transactions with the latest block hash
  * (not nice but convenient)
  */
 export const getSolanaTransactionFees = async (
-  txs: (
-    | {
-        kind: "legacy";
-        instance: SolanaLegacyTransaction;
-        hasThirdPartySignatures: boolean;
-      }
-    | {
-        kind: "versioned";
-        instance: SolanaVersionedTransaction;
-        hasThirdPartySignatures: boolean;
-      }
-  )[],
+  txs: (TaggedLegacyTransaction | TaggedVersionedTransaction)[],
   network: SolanaNetwork,
   price: number,
   additionalFee: ReturnType<typeof toBN>
@@ -58,19 +106,7 @@ export const getSolanaTransactionFees = async (
     // Use the latest block hash in-case it's fallen too far behind
     // (can't change block hash if it's already signed)
     if (!tx.hasThirdPartySignatures) {
-      switch (tx.kind) {
-        case "legacy":
-          tx.instance.recentBlockhash = latestBlockHash.blockhash;
-          break;
-        case "versioned":
-          tx.instance.message.recentBlockhash = latestBlockHash.blockhash;
-          break;
-        default:
-          tx satisfies never;
-          throw new Error(
-            `Unexpected Solana transaction kind ${(tx as any).kind}`
-          );
-      }
+      setTxBlockHash(tx, latestBlockHash.blockhash);
     }
 
     // Not sure why but getFeeForMessage sometimes returns null, so we will retry
@@ -82,25 +118,12 @@ export const getSolanaTransactionFees = async (
     // eslint-disable-next-line no-constant-condition
     while (true) {
       if (attempt >= backoff.length) {
-        let recentBlockHash: undefined | string;
-        switch (tx.kind) {
-          case "legacy":
-            recentBlockHash = tx.instance.recentBlockhash;
-            break;
-          case "versioned":
-            recentBlockHash = tx.instance.message.recentBlockhash;
-            break;
-          default:
-            tx satisfies never;
-            throw new Error(
-              `Unexpected Solana transaction kind ${(tx as any).kind}`
-            );
-        }
+        const blockHash = getTxBlockHash(tx);
         throw new Error(
           `Failed to get fee for Solana transaction ${txi + 1}` +
             ` after ${backoff.length} attempts.` +
             ` Transaction block hash` +
-            ` ${recentBlockHash} possibly expired.` +
+            ` ${blockHash} possibly expired.` +
             `  txkind=${txkind}`
         );
       }
@@ -111,74 +134,24 @@ export const getSolanaTransactionFees = async (
       // Update the block hash in-case it caused 0 fees to be returned
       if (attempt > 0) {
         if (!tx.hasThirdPartySignatures) {
-          let recentBlockHash: undefined | string;
-          switch (tx.kind) {
-            case "legacy":
-              recentBlockHash = tx.instance.recentBlockhash;
-              break;
-            case "versioned":
-              recentBlockHash = tx.instance.message.recentBlockhash;
-              break;
-            default:
-              tx satisfies never;
-              throw new Error(
-                `Unexpected Solana transaction kind ${(tx as any).kind}`
-              );
-          }
+          const blockHash = getTxBlockHash(tx);
           console.warn(
             `Cannot update block hash for signed transaction` +
               ` ${txi + 1}, retrying getFeeForMessage using the same` +
-              ` block hash ${recentBlockHash}` +
+              ` block hash ${blockHash}` +
               `  txkind=${txkind}`
           );
         } else {
           latestBlockHash = await conn.getLatestBlockhash();
-          switch (tx.kind) {
-            case "legacy":
-              tx.instance.recentBlockhash = latestBlockHash.blockhash;
-              break;
-            case "versioned":
-              tx.instance.message.recentBlockhash = latestBlockHash.blockhash;
-              break;
-            default:
-              tx satisfies never;
-              throw new Error(
-                `Unexpected Solana transaction kind ${(tx as any).kind}`
-              );
-          }
+          setTxBlockHash(tx, latestBlockHash.blockhash);
         }
       }
 
       /** Base fee + priority fee (Don't know why this returns null sometimes) */
-      let msg: Message | VersionedMessage;
-      switch (tx.kind) {
-        case "legacy":
-          msg = tx.instance.compileMessage();
-          break;
-        case "versioned":
-          msg = tx.instance.message;
-          break;
-        default:
-          throw new Error(
-            `Unexpected Solana transaction kind ${(tx as any).kind}`
-          );
-      }
+      const msg = getTxMessage(tx);
       const feeResult = await conn.getFeeForMessage(msg);
       if (feeResult.value == null) {
-        let recentBlockHash: undefined | string;
-        switch (tx.kind) {
-          case "legacy":
-            recentBlockHash = tx.instance.recentBlockhash;
-            break;
-          case "versioned":
-            recentBlockHash = tx.instance.message.recentBlockhash;
-            break;
-          default:
-            tx satisfies never;
-            throw new Error(
-              `Unexpected Solana transaction kind ${(tx as any).kind}`
-            );
-        }
+        const recentBlockHash = getTxBlockHash(tx);
         console.warn(
           `Failed to get fee for Solana transaction ${txi + 1}/${len}.` +
             ` Transaction block hash ${recentBlockHash}` +

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -118,8 +118,7 @@ class Swap extends EventEmitter {
           new Jupiter(this.api as Web3Solana, this.network),
           // TODO: re-enable Rango on Solana when issues with it are fixed
           // new Rango(this.api as Web3Solana, this.network),
-          // TODO: re-enable Changelly on Solana when issues with it are fixed
-          // new Changelly(this.api, this.network),
+          new Changelly(this.api, this.network),
         ];
         break;
       default:

--- a/packages/swap/src/providers/changelly/index.ts
+++ b/packages/swap/src/providers/changelly/index.ts
@@ -10,6 +10,8 @@ import {
   TransactionMessage,
   Connection,
   TransactionInstruction,
+  ComputeBudgetInstruction,
+  ComputeBudgetProgram,
 } from "@solana/web3.js";
 import {
   ASSOCIATED_TOKEN_PROGRAM_ID,
@@ -44,7 +46,7 @@ import {
 } from "../../configs";
 
 import { getTransfer } from "../../utils/approvals";
-import supportedNetworks from "./supported";
+import supportedNetworks, { supportedNetworksSet } from "./supported";
 import {
   ChangellyApiCreateFixedRateTransactionParams,
   ChangellyApiCreateFixedRateTransactionResult,
@@ -133,6 +135,7 @@ class Changelly extends ProviderClass {
 
   async init(): Promise<void> {
     debug("init", "Initialising...");
+
     if (!Changelly.isSupported(this.network)) {
       debug(
         "init",
@@ -151,15 +154,16 @@ class Changelly extends ProviderClass {
     });
 
     /** List of changelly blockchain names */
-    const supportedChangellyNames = Object.values(supportedNetworks).map(
-      (s) => s.changellyName
+    const supportedChangellyNames = new Set(
+      Object.values(supportedNetworks).map((s) => s.changellyName)
     );
 
     this.changellyList.forEach((cur) => {
       // Must be a supported token
-      if (!supportedChangellyNames.includes(cur.blockchain)) {
+      if (!supportedChangellyNames.has(cur.blockchain)) {
         return;
       }
+
       if (
         cur.enabledFrom &&
         cur.fixRateEnabled &&
@@ -184,6 +188,7 @@ class Changelly extends ProviderClass {
           },
         };
       }
+
       if (cur.token)
         this.setTicker(
           cur.token,
@@ -211,9 +216,7 @@ class Changelly extends ProviderClass {
   }
 
   static isSupported(network: SupportedNetworkName) {
-    return Object.keys(supportedNetworks).includes(
-      network as unknown as string
-    );
+    return supportedNetworksSet.has(network);
   }
 
   /**
@@ -561,15 +564,24 @@ class Changelly extends ProviderClass {
         );
         const original = firstChangellyFixRateQuote.amountTo;
         // eslint-disable-next-line no-use-before-define
-        const [success, fixed] = trimDecimals(
+        const [success, fixed] = fixBaseAndTrimDecimals(
           original,
           options.toToken.decimals
         );
         if (!success) throw err;
-        const rounded = (
-          BigInt(toBase(fixed, options.toToken.decimals)) - BigInt(1)
-        ).toString();
+        const rounded = (BigInt(fixed) - BigInt(1)).toString();
         toTokenAmountBase = rounded;
+
+        debug(
+          "getQuote",
+          `Fixed amountTo` +
+            `  firstChangellyFixRateQuote.amountTo=${firstChangellyFixRateQuote.amountTo}` +
+            `  toTokenAmountBase=${toTokenAmountBase}` +
+            `  options.toToken.decimals=${options.toToken.decimals}` +
+            `  options.toToken.symbol=${options.toToken.symbol}` +
+            `  options.toToken.name=${options.toToken.name}` +
+            `  options.toToken.address=${options.toToken.address}`
+        );
       }
 
       // `toBase` fails sometimes because Changelly returns more decimals than the token has
@@ -589,15 +601,24 @@ class Changelly extends ProviderClass {
         );
         const original = firstChangellyFixRateQuote.networkFee;
         // eslint-disable-next-line no-use-before-define
-        const [success, fixed] = trimDecimals(
+        const [success, fixed] = fixBaseAndTrimDecimals(
           original,
           options.toToken.decimals
         );
         if (!success) throw err;
-        const rounded = (
-          BigInt(toBase(fixed, options.toToken.decimals)) + BigInt(1)
-        ).toString();
+        const rounded = (BigInt(fixed) + BigInt(1)).toString();
         networkFeeBase = rounded;
+
+        debug(
+          "getQuote",
+          `Fixed networkFee` +
+            `  firstChangellyFixRateQuote.networkFee=${firstChangellyFixRateQuote.networkFee}` +
+            `  networkFeeBase=${networkFeeBase}` +
+            `  options.toToken.decimals=${options.toToken.decimals}` +
+            `  options.toToken.symbol=${options.toToken.symbol}` +
+            `  options.toToken.name=${options.toToken.name}` +
+            `  options.toToken.address=${options.toToken.address}`
+        );
       }
 
       const providerQuoteResponse: ProviderQuoteResponse = {
@@ -751,9 +772,7 @@ class Changelly extends ProviderClass {
           break;
         }
         case NetworkType.Solana: {
-          // TODO: finish implementing support for Solana
           debug("getSwap", `Changelly is not supported on Solana at this time`);
-          if (true as any) return null;
 
           const conn = this.web3 as Connection;
 
@@ -762,6 +781,8 @@ class Changelly extends ProviderClass {
           // Create a transaction to transfer this much of that token to that thing
           let versionedTx: VersionedTransaction;
           if (quote.options.fromToken.address === NATIVE_TOKEN_ADDRESS) {
+            // Swapping from native SOL
+
             debug(
               "getSwap",
               `Preparing Solana Changelly SOL swap transaction` +
@@ -785,52 +806,62 @@ class Changelly extends ProviderClass {
               }).compileToV0Message()
             );
           } else {
-            const wallet = new PublicKey(quote.options.fromAddress);
+            // Swapping from a token on SOL
+
+            // We need to send our src tokens to the payin address
+            // for Changelly to begin the cross-chain swap
+            // But first we'll need to create the src mint ATA for the payin address
+            // so it can receive the tokens
             const mint = new PublicKey(quote.options.fromToken.address);
             const tokenProgramId = await getTokenProgramOfMint(conn, mint);
-            const walletMintAta = getSPLAssociatedTokenAccountPubkey(
+            const wallet = new PublicKey(quote.options.fromAddress);
+            const walletAta = getSPLAssociatedTokenAccountPubkey(
               wallet,
               mint,
               tokenProgramId
             );
-            // TODO: is payin address an ATA or Wallet address? (must be wallet, right?)
-            const payinAta = new PublicKey(changellyFixedRateTx.payinAddress);
+            const payin = new PublicKey(changellyFixedRateTx.payinAddress);
+            const payinAta = getSPLAssociatedTokenAccountPubkey(
+              payin,
+              mint,
+              tokenProgramId
+            );
             const amount = BigInt(quote.options.amount.toString());
             debug(
               "getSwap",
-              // eslint-disable-next-line prefer-template
               `Preparing Solana Changelly SPL token swap transaction` +
                 `  srcMint=${mint.toBase58()}` +
+                `  srcTokenProgramId=${tokenProgramId.toBase58()}` +
                 `  wallet=${wallet.toBase58()}` +
-                `  walletSrcMintAta=${tokenProgramId.toBase58()}` +
-                `  dstMintAta=${payinAta.toBase58()}` +
-                `  tokenProgramId=${tokenProgramId.toBase58()}` +
+                `  walletAta=${tokenProgramId.toBase58()}` +
+                `  payin=${payin.toBase58()}` +
+                `  payinAta=${payinAta.toBase58()}` +
                 `  latestBlockHash=${latestBlockHash.blockhash}` +
                 `  lastValidBlockHeight=${latestBlockHash.lastValidBlockHeight}` +
-                `  payinAddress=${changellyFixedRateTx.payinAddress}` +
                 `  amount=${amount}`
             );
 
             // If the ATA account doesn't exist we need create it
-            const ataExists = await solAccountExists(conn, payinAta);
+            const payinAtaExists = await solAccountExists(conn, payinAta);
+
+            // We probably need to set some priority fees? IDK...
 
             const instructions: TransactionInstruction[] = [];
-            if (ataExists) {
+            if (payinAtaExists) {
               debug(
                 "getSwap",
                 `Payin ATA already exists. No need to create it.`
               );
             } else {
               debug("getSwap", `Payin ATA does not exist. Need to create it.`);
-              // TODO: finish implementing
               const extraRentFee = await conn.getMinimumBalanceForRentExemption(
                 SPL_TOKEN_ATA_ACCOUNT_SIZE_BYTES
               );
               const instruction =
                 getCreateAssociatedTokenAccountIdempotentInstruction({
                   payerPubkey: wallet,
-                  ataPubkey: payinAta, // TODO: we'd need to get the owner
-                  ownerPubkey: new PublicKey("!! TODO !!"),
+                  ataPubkey: payinAta,
+                  ownerPubkey: payin,
                   mintPubkey: mint,
                   systemProgramId: SystemProgram.programId,
                   tokenProgramId,
@@ -843,9 +874,82 @@ class Changelly extends ProviderClass {
               );
             }
 
+            /** Priority fee (units: micro lamports per compute unit) in recent transactions */
+            const recentFees = await conn.getRecentPrioritizationFees();
+            // Sort by fee amount ascending so we can get the median
+            recentFees.sort(
+              (a, b) => a.prioritizationFee - b.prioritizationFee
+            );
+            const recentFeeCount = recentFees.length;
+            let recentFeeCountWithoutZeroes = 0;
+            let recentFeeMin = 0;
+            let recentFeeMax = 0;
+            let recentFeeSum = 0;
+            let recentFeeMedian = 0;
+            const recentFeeMediani = Math.floor(recentFeeCount / 2);
+            // Use the minimum of the mean average and median average as our priority fee
+            for (
+              let recentFeei = 0;
+              recentFeei < recentFeeCount;
+              recentFeei++
+            ) {
+              const { prioritizationFee } = recentFees[recentFeei];
+              recentFeeSum += prioritizationFee;
+              if (recentFeei === recentFeeMediani)
+                recentFeeMedian = prioritizationFee;
+              if (prioritizationFee > 0) recentFeeCountWithoutZeroes++;
+              if (prioritizationFee < recentFeeMin)
+                recentFeeMin = prioritizationFee;
+              if (prioritizationFee > recentFeeMax)
+                recentFeeMax = prioritizationFee;
+            }
+            const recentFeeMean = recentFeeSum / recentFeeCountWithoutZeroes;
+            const recentFeeMinAvg = Math.min(recentFeeMean, recentFeeMedian);
+
+            // TODO: Do we want to set the compute budget? What should we set it to?
+            // Set compute budget
+            // instructions.unshift(
+            //   ComputeBudgetProgram.setComputeUnitLimit()
+            // )
+
+            // Set priority fee
+            if (recentFeeMinAvg <= 0) {
+              debug(
+                "getSwap",
+                `No recent fees, not setting priority fee` +
+                  `  recentFeeCount=${recentFeeCount}` +
+                  `  recentFeeCountWithoutZeroes=${recentFeeCountWithoutZeroes}` +
+                  `  recentFeeSum=${recentFeeSum}` +
+                  `  recentFeeMin=${recentFeeMin}` +
+                  `  recentFeeMax=${recentFeeMax}` +
+                  `  recentFeeMean=${recentFeeMean}` +
+                  `  recentFeeMedian=${recentFeeMedian}` +
+                  `  recentFeeMinAvg=${recentFeeMinAvg}`
+              );
+            } else {
+              debug(
+                "getSwap",
+                `Setting priority fee` +
+                  `  priority_fee=${recentFeeMinAvg} micro_lamports/compute_unit` +
+                  `  recentFeeCount=${recentFeeCount}` +
+                  `  recentFeeCountWithoutZeroes=${recentFeeCountWithoutZeroes}` +
+                  `  recentFeeSum=${recentFeeSum}` +
+                  `  recentFeeMin=${recentFeeMin}` +
+                  `  recentFeeMax=${recentFeeMax}` +
+                  `  recentFeeMean=${recentFeeMean}` +
+                  `  recentFeeMedian=${recentFeeMedian}` +
+                  `  recentFeeMinAvg=${recentFeeMinAvg}`
+              );
+              instructions.unshift(
+                ComputeBudgetProgram.setComputeUnitPrice({
+                  microLamports: recentFeeMinAvg,
+                })
+              );
+            }
+
             instructions.push(
               createSPLTransferInstruction(
-                /** source */ walletMintAta,
+                /** source */ walletAta,
                 /** destination */ payinAta,
                 /** owner */ wallet,
                 /** amount */ amount,
@@ -873,7 +977,9 @@ class Changelly extends ProviderClass {
           };
           break;
         }
+
         default: {
+          // Not EVM, not SOlana
           transaction = {
             from: quote.options.fromAddress,
             to: changellyFixedRateTx.payinAddress,
@@ -902,15 +1008,24 @@ class Changelly extends ProviderClass {
         );
         const original = changellyFixedRateTx.amountExpectedTo;
         // eslint-disable-next-line no-use-before-define
-        const [success, fixed] = trimDecimals(
+        const [success, fixed] = fixBaseAndTrimDecimals(
           original,
           quote.options.toToken.decimals
         );
         if (!success) throw err;
-        const rounded = (
-          BigInt(toBase(fixed, quote.options.toToken.decimals)) - BigInt(1)
-        ).toString();
+        const rounded = (BigInt(fixed) - BigInt(1)).toString();
         baseToAmount = rounded;
+
+        debug(
+          "getQuote",
+          `Fixed amountExpectedTo` +
+            `  changellyFixedRateTx.amountExpectedTo=${changellyFixedRateTx.amountExpectedTo}` +
+            `  baseToAmount=${baseToAmount}` +
+            `  quote.options.toToken.decimals=${quote.options.toToken.decimals}` +
+            `  quote.options.toToken.symbol=${quote.options.toToken.symbol}` +
+            `  quote.options.toToken.name=${quote.options.toToken.name}` +
+            `  quote.options.toToken.address=${quote.options.toToken.address}`
+        );
       }
 
       const retResponse: ProviderSwapResponse = {
@@ -974,7 +1089,7 @@ class Changelly extends ProviderClass {
   }
 }
 
-function trimDecimals(
+function fixBaseAndTrimDecimals(
   value: string,
   decimals: number
 ): [success: boolean, fixed: string] {

--- a/packages/swap/src/providers/changelly/supported.ts
+++ b/packages/swap/src/providers/changelly/supported.ts
@@ -1,6 +1,7 @@
 // import { isValidSolanaAddress } from "../../utils/solana";
 import { isPolkadotAddress, isEVMAddress } from "../../utils/common";
 import { SupportedNetworkName } from "../../types";
+import { isValidSolanaAddress } from "../../utils/solana";
 
 /**
  * Blockchain names:
@@ -13,7 +14,7 @@ import { SupportedNetworkName } from "../../types";
  * ````
  */
 const supportedNetworks: {
-  [key in SupportedNetworkName]?: {
+  readonly [key in SupportedNetworkName]?: {
     changellyName: string;
     isAddress?: (addr: string) => Promise<boolean>;
   };
@@ -61,17 +62,19 @@ const supportedNetworks: {
   [SupportedNetworkName.Dogecoin]: {
     changellyName: "doge",
   },
-  // TODO: Re-enable Solana when all issues with Changelly and Solana on Enkrypt are fixed
-  // @2024-10-01
-  // [SupportedNetworkName.Solana]: {
-  //   changellyName: "solana",
-  //   async isAddress(address: string) {
-  //     return isValidSolanaAddress(address);
-  //   },
-  // },
+  [SupportedNetworkName.Solana]: {
+    changellyName: "solana",
+    async isAddress(address: string) {
+      return isValidSolanaAddress(address);
+    },
+  },
   [SupportedNetworkName.Rootstock]: {
     changellyName: "rootstock",
   },
 };
+
+export const supportedNetworksSet = new Set(
+  Object.keys(supportedNetworks)
+) as unknown as Set<SupportedNetworkName>;
 
 export default supportedNetworks;


### PR DESCRIPTION
Enable Changelly on Solana including in-chain and cross-chain swaps of both tokens and native SOL.

Also fix a bug introduced by me in the initial Solana release where if Changelly returns a value with too many numbers beyond the decimal point (more than the tokens decimals) then the base amount will be calculated incorrectly.

Also set priority fees for Changelly Solana transactions because otherwise they weren't being mined sometimes.

Also some minor code cleanup.