### PR TITLE
feat: enable rango rango swap on solana

### DIFF
--- a/packages/extension/src/ui/action/views/swap/libs/send-transactions.ts
+++ b/packages/extension/src/ui/action/views/swap/libs/send-transactions.ts
@@ -184,8 +184,9 @@ export const executeSwap = async (
     const enkSolTxs = options.swap.transactions as EnkryptSolanaTransaction[];
 
     // Execute each transaction in-order one-by-one
-    for (const enkSolTx of enkSolTxs) {
+    for (let i = 0, len = enkSolTxs.length; i < len; i++) {
       // Transform the Enkrypt representation of the transaction into the Solana lib's representation
+      const enkSolTx = enkSolTxs[i];
 
       let serialized: Uint8Array;
       switch (enkSolTx.kind) {
@@ -194,6 +195,73 @@ export const executeSwap = async (
           // (note: the transaction may already be signed by a third party like Rango exchange)
           const bytes = Buffer.from(enkSolTx.serialized, "base64");
           const legacyTx = SolanaLegacyTransaction.from(bytes);
+          const { thirdPartySignatures } = enkSolTx;
+
+          const hasThirdPartySignatures =
+            // Serialized versioned transaction was already signed
+            legacyTx.signatures.length > 1 ||
+            // Need to apply third aprty signatures to the transaction
+            thirdPartySignatures.length > 0;
+
+          if (hasThirdPartySignatures) {
+            // Can't sign the transaction since it's signed / to be signed by third parties
+          } else {
+            // We can update the transaction since it's unsigned
+            // Check if we need to update the block hash
+            let shouldUpdateBlockHash: boolean;
+            try {
+              // We won't be able to get the fee if the block hash is too old
+              const fee = await legacyTx.getEstimatedFee(conn);
+              shouldUpdateBlockHash = fee == null;
+            } catch (err) {
+              // Might need to update the block hash
+              console.warn(
+                `Failed to get fee for legacy transaction while checking` +
+                  ` whether to update block hash: ${String(err)}`
+              );
+              shouldUpdateBlockHash = true;
+            }
+
+            // Try to update the block hash
+            if (shouldUpdateBlockHash) {
+              console.warn(
+                `Unsigned legacy transaction might have an` +
+                  ` out-of-date block hash, trying to update it...`
+              );
+              const backoff = [0, 500, 1_000, 2_000];
+              let backoffi = 0;
+              // eslint-disable-next-line no-constant-condition
+              update_block_hash: while (true) {
+                if (backoffi >= backoff.length) {
+                  // Just continue and hope for the best with old block hash...
+                  console.warn(
+                    `Failed to get latest blockhash after ${backoffi} attempts,` +
+                      ` continuing with old block hash for legacy transaction...`
+                  );
+                  break update_block_hash;
+                }
+                const backoffMs = backoff[backoffi];
+                if (backoffMs > 0) {
+                  console.warn(
+                    `Waiting ${backoffMs}ms before retrying latest block` +
+                      ` hash for legacy transaction...`
+                  );
+                  await new Promise((res) => setTimeout(res, backoffMs));
+                }
+                try {
+                  const latest = await conn.getLatestBlockhash();
+                  legacyTx.recentBlockhash = latest.blockhash;
+                  break update_block_hash;
+                } catch (err) {
+                  console.warn(
+                    `Failed to get latest blockhash on attempt` +
+                      ` ${backoffi + 1}: ${String(err)}`
+                  );
+                }
+                backoffi++;
+              }
+            }
+          }
 
           // Sign the transaction message
           // Use the keyring running in the background script
@@ -211,7 +279,6 @@ export const executeSwap = async (
             );
           });
           // Add third party signatures (eg Rango)
-          const { thirdPartySignatures } = enkSolTx;
           for (let i = 0, len = thirdPartySignatures.length; i < len; i++) {
             const { pubkey, signature } = enkSolTx.thirdPartySignatures[i];
             legacyTx.addSignature(
@@ -236,10 +303,77 @@ export const executeSwap = async (
 
           const bytes = Buffer.from(enkSolTx.serialized, "base64");
           const versionedTx = SolanaVersionedTransaction.deserialize(bytes);
+          const { thirdPartySignatures } = enkSolTx;
+
+          const hasThirdPartySignatures =
+            // Serialized versioned transaction was already signed
+            versionedTx.signatures.length > 1 ||
+            // Need to apply third aprty signatures to the transaction
+            thirdPartySignatures.length > 0;
+
+          if (hasThirdPartySignatures) {
+            // Can't sign the transaction since it's signed / to be signed by third parties
+          } else {
+            // We can update the transaction since it's unsigned
+            // Check if we need to update the block hash
+            let shouldUpdateBlockHash: boolean;
+            try {
+              // We won't be able to get the fee if the block hash is too old
+              const msg = versionedTx.message;
+              const fee = await conn.getFeeForMessage(msg);
+              shouldUpdateBlockHash = fee.value == null;
+            } catch (err) {
+              // Might need to update the block hash
+              console.warn(
+                `Failed to get fee for versioned transaction while checking` +
+                  ` whether to update block hash: ${String(err)}`
+              );
+              shouldUpdateBlockHash = true;
+            }
+
+            // Try to update the block hash
+            if (shouldUpdateBlockHash) {
+              console.warn(
+                `Unsigned versioned transaction might have an` +
+                  ` out-of-date block hash, trying to update it...`
+              );
+              const backoff = [0, 500, 1_000, 2_000];
+              let backoffi = 0;
+              // eslint-disable-next-line no-constant-condition
+              update_block_hash: while (true) {
+                if (backoffi >= backoff.length) {
+                  // Just continue and hope for the best with old block hash...
+                  console.warn(
+                    `Failed to get latest blockhash after ${backoffi} attempts,` +
+                      ` continuing with old block hash for versioned transaction...`
+                  );
+                  break update_block_hash;
+                }
+                const backoffMs = backoff[backoffi];
+                if (backoffMs > 0) {
+                  console.warn(
+                    `Waiting ${backoffMs}ms before retrying latest block` +
+                      ` hash for versioned transaction...`
+                  );
+                  await new Promise((res) => setTimeout(res, backoffMs));
+                }
+                try {
+                  const latest = await conn.getLatestBlockhash();
+                  versionedTx.message.recentBlockhash = latest.blockhash;
+                  break update_block_hash;
+                } catch (err) {
+                  console.warn(
+                    `Failed to get latest blockhash on attempt` +
+                      ` ${backoffi + 1}: ${String(err)}`
+                  );
+                }
+                backoffi++;
+              }
+            }
+          }
 
           // Sign the transaction message
           // Use the keyring running in the background script
-
           const sigRes = await SolanaTransactionSigner({
             account: options.from,
             network: options.network,
@@ -252,7 +386,6 @@ export const executeSwap = async (
           });
 
           // Add third party signatures (eg Rango)
-          const { thirdPartySignatures } = enkSolTx;
           for (let i = 0, len = thirdPartySignatures.length; i < len; i++) {
             const { pubkey, signature } = enkSolTx.thirdPartySignatures[i];
             versionedTx.addSignature(
@@ -286,6 +419,22 @@ export const executeSwap = async (
         // The Solana web3 library prompts you to call getLogs if your error is of type
         // SendTransactionError to get more info about the error
         if (err instanceof SendTransactionError) {
+          const errstr = String(err);
+
+          // The error thrown here is shown to the user in the UI
+          // so make it descriptive if possible
+          if (errstr.includes("Blockhash not found")) {
+            console.error(
+              `Failed to send Solana swap transaction: blockhash not found`,
+              err
+            );
+            throw new Error(
+              "Failed to send Solana swap transaction: blockhash not found." +
+                " Too much time may have passed between the creation and sending" +
+                " of the transaction"
+            );
+          }
+
           try {
             const logs = await err.getLogs(conn);
             console.error(

--- a/packages/extension/src/ui/action/views/swap/libs/send-transactions.ts
+++ b/packages/extension/src/ui/action/views/swap/libs/send-transactions.ts
@@ -204,7 +204,9 @@ export const executeSwap = async (
             thirdPartySignatures.length > 0;
 
           if (hasThirdPartySignatures) {
-            // Can't sign the transaction since it's signed / to be signed by third parties
+            // Can't update the block hash since it's signed / to be signed by third parties
+            // If the user waits too long before sending, the transaction may fail due to
+            // becoming out-of-date
           } else {
             // We can update the transaction since it's unsigned
             // Check if we need to update the block hash
@@ -312,7 +314,9 @@ export const executeSwap = async (
             thirdPartySignatures.length > 0;
 
           if (hasThirdPartySignatures) {
-            // Can't sign the transaction since it's signed / to be signed by third parties
+            // Can't update the block hash since it's signed / to be signed by third parties
+            // If the user waits too long before sending, the transaction may fail due to
+            // becoming out-of-date
           } else {
             // We can update the transaction since it's unsigned
             // Check if we need to update the block hash

--- a/packages/swap/src/index.ts
+++ b/packages/swap/src/index.ts
@@ -116,8 +116,7 @@ class Swap extends EventEmitter {
         // Solana
         this.providers = [
           new Jupiter(this.api as Web3Solana, this.network),
-          // TODO: re-enable Rango on Solana when issues with it are fixed
-          // new Rango(this.api as Web3Solana, this.network),
+          new Rango(this.api as Web3Solana, this.network),
           // TODO: re-enable Changelly on Solana when issues with it are fixed
           // new Changelly(this.api, this.network),
         ];

--- a/packages/swap/src/providers/rango/index.ts
+++ b/packages/swap/src/providers/rango/index.ts
@@ -13,7 +13,6 @@ import {
   EvmTransaction as RangoEvmTransaction,
   RangoClient,
   TransactionStatus as RangoTransactionStatus,
-  MetaResponse,
   SwapRequest,
   BlockchainMeta,
   RoutingResultType,
@@ -105,6 +104,15 @@ if (DEBUG) {
   debug = () => {};
 }
 
+type SupportedNetworkInfo = {
+  /** Standard base10 chain ID, can be obtained from `https://chainlist.org` */
+  realChainId: string;
+  /** Rango's chainId for Solana is "mainnet-beta" */
+  rangoChainId: string;
+  /** Rango blockchain name (Rango's identifier for the chain) of a network */
+  rangoBlockchain: string;
+};
+
 /**
  * `name` is the blockchain id on Rango
  *
@@ -113,87 +121,163 @@ if (DEBUG) {
  * @see https://rango-api.readme.io/reference/meta
  *
  * ```sh
- * curl 'https://api.rango.exchange/basic/meta?apiKey=c6381a79-2817-4602-83bf-6a641a409e32' -H 'Accept:application/json'
+ * # Rango token meta (list of all tokens with token metadata, blockchain info, etc)
+ * curl 'https://api.rango.exchange/basic/meta?apiKey=c6381a79-2817-4602-83bf-6a641a409e32' -sL -H 'Accept:application/json' | jq .
+ * # {
+ * #   "tokens": [
+ * #     {
+ * #       "blockchain": "ETH",
+ * #       "symbol": "USDT",
+ * #       "name": "USD Tether",
+ * #       "isPopular": true,
+ * #       "chainId": "1",
+ * #       "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+ * #       "decimals": 6,
+ * #       "image": "https://rango.vip/i/r3Oex6",
+ * #       "blockchainImage": "https://raw.githubusercontent.com/rango-exchange/assets/main/blockchains/ETH/icon.svg",
+ * #       "usdPrice": 1.001,
+ * #       "supportedSwappers": [
+ * #         "Arbitrum Bridge",
+ * #         "ThorChain",
+ * # ...
+ *
+ * # Rango token count per blockchain
+ * curl 'https://api.rango.exchange/basic/meta?apiKey=c6381a79-2817-4602-83bf-6a641a409e32' -sL -H 'Accept:application/json' | jq --raw-output .tokens[].blockchain | sort | uniq -c | sort -n
+ * # count blockchain
+ * # ...
+ * #    36 MOONBEAM
+ * #    42 CELO
+ * #    48 OKC
+ * #    50 MOONRIVER
+ * #    55 AURORA
+ * #    56 LINEA
+ * #    58 ZKSYNC
+ * #    61 BLAST
+ * #   146 OSMOSIS
+ * #   147 HECO
+ * #   158 CRONOS
+ * #   301 OPTIMISM
+ * #   368 AVAX_CCHAIN
+ * #   437 BASE
+ * #   594 POLYGON
+ * #   596 ARBITRUM
+ * #   833 BSC
+ * #  1509 SOLANA
+ * #  5610 ETH
+ *
+ * # Rango token count per blockchain & chain id
+ * curl 'https://api.rango.exchange/basic/meta?apiKey=c6381a79-2817-4602-83bf-6a641a409e32' -sL -H 'Accept:application/json' | jq -r '.tokens[] | "\(.blockchain)\t\(.chainId)"' | sort | uniq -c | sort -n | sed 's/^ *\([0-9]*\) *\(.*\)/\1\t\2/' | column -s $'\t' -t
+ * # count blockchain     chain id
+ * # ...
+ * # 50    MOONRIVER      1285
+ * # 55    AURORA         1313161554
+ * # 56    LINEA          59144
+ * # 58    ZKSYNC         324
+ * # 61    BLAST          81457
+ * # 146   OSMOSIS        osmosis-1
+ * # 147   HECO           128
+ * # 158   CRONOS         25
+ * # 301   OPTIMISM       10
+ * # 368   AVAX_CCHAIN    43114
+ * # 437   BASE           8453
+ * # 594   POLYGON        137
+ * # 596   ARBITRUM       42161
+ * # 833   BSC            56
+ * # 1509  SOLANA         mainnet-beta
+ * # 5610  ETH            1
  * ```
  */
-const supportedNetworks: {
-  [key in SupportedNetworkName]?: {
-    /** Standard base10 chain ID, can be obtained from `https://chainlist.org` */
-    realChainId: string;
-    /** Rango's chainId for Solana is "mainnet-beta" */
-    rangoChainId: string;
-    /** Rango name (Rango's identifier for the chain) of a network */
-    name: string;
-  };
-} = {
+const supportedNetworks: Readonly<{
+  [key in SupportedNetworkName]?: SupportedNetworkInfo;
+}> = {
   [SupportedNetworkName.Ethereum]: {
     realChainId: "1",
     rangoChainId: "1",
-    name: "ETH",
+    rangoBlockchain: "ETH",
   },
   [SupportedNetworkName.Binance]: {
     realChainId: "56",
     rangoChainId: "56",
-    name: "BSC",
+    rangoBlockchain: "BSC",
   },
   [SupportedNetworkName.Matic]: {
     realChainId: "137",
     rangoChainId: "137",
-    name: "POLYGON",
+    rangoBlockchain: "POLYGON",
   },
   [SupportedNetworkName.Optimism]: {
     realChainId: "10",
     rangoChainId: "10",
-    name: "OPTIMISM",
+    rangoBlockchain: "OPTIMISM",
   },
   [SupportedNetworkName.Avalanche]: {
     realChainId: "43114",
     rangoChainId: "43114",
-    name: "AVAX_CCHAIN",
+    rangoBlockchain: "AVAX_CCHAIN",
   },
   [SupportedNetworkName.Fantom]: {
     realChainId: "250",
     rangoChainId: "250",
-    name: "FANTOM",
+    rangoBlockchain: "FANTOM",
   },
   [SupportedNetworkName.Aurora]: {
     realChainId: "1313161554",
     rangoChainId: "1313161554",
-    name: "AURORA",
+    rangoBlockchain: "AURORA",
   },
   [SupportedNetworkName.Gnosis]: {
     realChainId: "100",
     rangoChainId: "100",
-    name: "GNOSIS",
+    rangoBlockchain: "GNOSIS",
   },
   [SupportedNetworkName.Arbitrum]: {
     realChainId: "42161",
     rangoChainId: "42161",
-    name: "ARBITRUM",
+    rangoBlockchain: "ARBITRUM",
   },
   [SupportedNetworkName.Moonbeam]: {
     realChainId: "1284",
     rangoChainId: "1284",
-    name: "MOONBEAM",
+    rangoBlockchain: "MOONBEAM",
   },
-  // TODO: Re-enable Solana when all issues with Rango and Solana on Enkrypt are fixed
-  // @2024-10-01
-  // [SupportedNetworkName.Solana]: {
-  //   realChainId: "900",
-  //   rangoChainId: "mainnet-beta",
-  //   name: "SOLANA",
-  // },
+  [SupportedNetworkName.Solana]: {
+    realChainId: "900",
+    rangoChainId: "mainnet-beta",
+    rangoBlockchain: "SOLANA",
+  },
   [SupportedNetworkName.Blast]: {
     realChainId: "81457",
     rangoChainId: "81457",
-    name: "BLAST",
+    rangoBlockchain: "BLAST",
   },
   [SupportedNetworkName.Telos]: {
     realChainId: "40",
     rangoChainId: "40",
-    name: "TELOS",
+    rangoBlockchain: "TELOS",
   },
 };
+
+// Freeze because we index below so modifications would make the indexes stale
+Object.freeze(supportedNetworks);
+
+/** Enkrypt supported network name -> network info */
+const supportedNetworkInfoByName = new Map(
+  Object.entries(supportedNetworks)
+) as unknown as Map<SupportedNetworkName, SupportedNetworkInfo>;
+
+/** Rango blockchain name -> network info & enkrypt network name */
+const supportedNetworkByRangoBlockchain = new Map<
+  string,
+  { info: SupportedNetworkInfo; name: SupportedNetworkName }
+>(
+  Object.entries(supportedNetworks).map(([supportedNetwork, networkInfo]) => [
+    networkInfo.rangoBlockchain,
+    {
+      info: networkInfo,
+      name: supportedNetwork as unknown as SupportedNetworkName,
+    },
+  ])
+);
 
 type RangoEnkryptToken = {
   rangoMeta: RangoToken;
@@ -213,7 +297,16 @@ class Rango extends ProviderClass {
 
   toTokens: ProviderToTokenResponse;
 
-  rangoMeta: MetaResponse;
+  rangoMeta: Readonly<{
+    blockchains: ReadonlyArray<BlockchainMeta>;
+    blockchainsByName: ReadonlyMap<string, BlockchainMeta>;
+    tokens: ReadonlyArray<RangoToken>;
+    tokensByAddress: ReadonlyMap<Lowercase<string>, RangoToken>;
+    tokensByBlockchainAddress: ReadonlyMap<
+      `${string}-${Lowercase<string>}`,
+      RangoToken
+    >;
+  }>;
 
   /** From GitHub */
   swaplist: RangoEnkryptToken[];
@@ -231,7 +324,13 @@ class Rango extends ProviderClass {
     this.name = ProviderName.rango;
     this.fromTokens = {};
     this.toTokens = {};
-    this.rangoMeta = { blockchains: [], tokens: [], swappers: [] };
+    this.rangoMeta = {
+      blockchains: [],
+      blockchainsByName: new Map(),
+      tokens: [],
+      tokensByAddress: new Map(),
+      tokensByBlockchainAddress: new Map(),
+    };
     this.transactionsStatus = [];
     this.swaplist = [];
     this.swaplistMap = new Map();
@@ -240,18 +339,18 @@ class Rango extends ProviderClass {
   async init(tokenList?: TokenType[]): Promise<void> {
     debug("init", `Initialising against ${tokenList?.length} tokens...`);
 
-    const [resMeta, swaplist] = await Promise.all([
+    const [rangoMeta, swaplist] = await Promise.all([
       rangoClient.meta({
         excludeNonPopulars: true,
         transactionTypes: [
           RangoTransactionType.EVM,
-          // TODO:  re-enable Solana transactions when Rango issues on Solana are fixed
-          // RangoTransactionType.SOLANA,
+          RangoTransactionType.SOLANA,
         ],
       }),
       fetchRangoSwaplist(),
     ]);
 
+    /** Rango blockchain id + lowercase address -> rango token meta */
     const swaplistMap = new Map<
       `${string}-${Lowercase<string>}`,
       RangoEnkryptToken
@@ -264,63 +363,145 @@ class Rango extends ProviderClass {
       swaplistMap.set(key, swaplistToken);
     }
 
+    const rangoBlockchains = rangoMeta.blockchains;
+    const rangoBlockchainsByName = new Map<string, BlockchainMeta>();
+    for (let i = 0, len = rangoBlockchains.length; i < len; i++) {
+      const rangoBlockchain = rangoBlockchains[i];
+      rangoBlockchainsByName.set(rangoBlockchain.name, rangoBlockchain);
+    }
+
+    const rangoTokens = rangoMeta.tokens;
+    const rangoTokensByAddress = new Map<Lowercase<string>, RangoToken>();
+    for (let i = 0, len = rangoTokens.length; i < len; i++) {
+      const rangoToken = rangoTokens[i];
+      const lcAddress = (rangoToken.address?.toLowerCase() ??
+        NATIVE_TOKEN_ADDRESS) as Lowercase<string>;
+      rangoTokensByAddress.set(lcAddress, rangoToken);
+    }
+    const rangoTokensByBlockchainAddress = new Map<
+      `${string}-${Lowercase<string>}`,
+      RangoToken
+    >();
+    for (let i = 0, len = rangoTokens.length; i < len; i++) {
+      const rangoToken = rangoTokens[i];
+      const lcAddress = (rangoToken.address?.toLowerCase() ??
+        NATIVE_TOKEN_ADDRESS) as Lowercase<string>;
+      const key: `${string}-${Lowercase<string>}` = `${rangoToken.blockchain}-${lcAddress}`;
+      rangoTokensByBlockchainAddress.set(key, rangoToken);
+    }
+
+    this.tokenList = tokenList ?? [];
     this.swaplist = swaplist;
     this.swaplistMap = swaplistMap;
+    this.rangoMeta = {
+      blockchains: rangoBlockchains,
+      blockchainsByName: rangoBlockchainsByName,
+      tokens: rangoTokens,
+      tokensByAddress: rangoTokensByAddress,
+      tokensByBlockchainAddress: rangoTokensByBlockchainAddress,
+    };
 
-    this.rangoMeta = resMeta;
     debug(
       "init",
       "Rango meta" +
-        `  tokens.length=${resMeta.tokens.length}` +
-        `  blockchains.length=${resMeta.blockchains.length}`
+        `  tokens.length=${rangoMeta.tokens.length}` +
+        `  blockchains.length=${rangoMeta.blockchains.length}`
     );
 
-    const { blockchains, tokens } = resMeta;
-    if (!Rango.isSupported(this.network, blockchains)) {
-      debug("init", `Not supported on network ${this.network}`);
+    const supportedNetworkInfo = supportedNetworkInfoByName.get(this.network);
+
+    if (!supportedNetworkInfo) {
+      debug("init", `Network not supported on Enkrypt+Rango: ${this.network}`);
       return;
     }
 
-    tokenList?.forEach((t) => {
-      const tokenSupport = tokens.find((token) => token.address === t.address);
-      if (this.isNativeToken(t.address) || tokenSupport) {
-        this.fromTokens[t.address] = t;
+    if (
+      !Rango.isNetworkSupportedByRango(supportedNetworkInfo, rangoBlockchains)
+    ) {
+      debug("init", `Network not supported on Rango: ${this.network}`);
+      return;
+    }
+
+    if (tokenList) {
+      // List available "from" tokens by matching between our swap list info and Rango token info, on this chain
+      for (let i = 0, len = tokenList.length; i < len; i++) {
+        /** Token from */
+        const listToken = tokenList[i];
+        const casedAddress = listToken.address;
+        const lcAddress = casedAddress.toLowerCase() as Lowercase<string>;
+        const key: `${string}-${Lowercase<string>}` = `${supportedNetworkInfo.rangoBlockchain}-${lcAddress}`;
+        /** Token from Rango API */
+        const rangoToken = rangoTokensByBlockchainAddress.get(key);
+        if (this.isNativeToken(casedAddress) || rangoToken) {
+          this.fromTokens[casedAddress] = listToken;
+        }
       }
-    });
+    }
 
     debug("init", `Finished initialising`);
   }
 
+  static findRangoBlockchainForSupportedNetwork(
+    supportedNetworkInfo: SupportedNetworkInfo,
+    rangoBlockchains: ReadonlyArray<BlockchainMeta>
+  ): undefined | BlockchainMeta {
+    const matchingRangoBlockchain = rangoBlockchains.find(
+      (rangoBlockchain: BlockchainMeta) =>
+        rangoChainIdsEq(
+          rangoBlockchain.chainId,
+          supportedNetworkInfo.rangoChainId
+        )
+    );
+
+    return matchingRangoBlockchain;
+  }
+
   /**
-   * Do we support any of the blockchains that Rango supports?
+   * Is this network supported by both enkrypt and rango?
    */
-  static isSupported(
-    network: SupportedNetworkName,
-    blockchains: BlockchainMeta[]
-  ) {
-    // We must support this network
-    if (
-      !Object.keys(supportedNetworks).includes(network as unknown as string)
-    ) {
+  static isNetworkSupported(
+    supportedNetworkName: SupportedNetworkName,
+    rangoBlockchains: ReadonlyArray<BlockchainMeta>
+  ): boolean {
+    const supportedNetworkInfo =
+      supportedNetworkInfoByName.get(supportedNetworkName);
+
+    // Enkrypt must support this network on Rango
+    if (!supportedNetworkInfo) {
       return false;
     }
 
-    if (blockchains.length) {
-      // Join Rango networks and our supported networks by their chain id
+    return this.isNetworkSupportedByRango(
+      supportedNetworkInfo,
+      rangoBlockchains
+    );
+  }
 
-      // Extract our info about this supported network
-      const [, { rangoChainId }] = Object.entries(supportedNetworks).find(
-        ([supportedNetworkName]) =>
-          supportedNetworkName === (network as unknown as string)
-      );
-      const enabled = !!blockchains.find((rangoBlockchain: BlockchainMeta) =>
-        rangoChainIdsEq(rangoBlockchain.chainId, rangoChainId)
-      )?.enabled;
-      return enabled;
+  /**
+   * Is this network that *we* support also supported by rango?
+   */
+  static isNetworkSupportedByRango(
+    supportedNetworkInfo: SupportedNetworkInfo,
+    rangoBlockchains: ReadonlyArray<BlockchainMeta>
+  ): boolean {
+    if (!rangoBlockchains.length) {
+      // Rango didn't give us anything so just assume Rango supports this network
+      // (maybe due to rango api error or something?)
+      return true;
     }
 
-    // Rango didn't give us anything so just assume Rango supports this network
-    return true;
+    // Rango must support this network
+
+    // Find the rango blockchain that corresponds to this enkrypt network, if exists
+    const matchingRangoBlockchain = this.findRangoBlockchainForSupportedNetwork(
+      supportedNetworkInfo,
+      rangoBlockchains
+    );
+
+    // Supported if
+    // 1. Rango supports this chain and
+    // 2. Rango is enabled on this chain
+    return matchingRangoBlockchain?.enabled ?? false;
   }
 
   getFromTokens(): ProviderFromTokenResponse {
@@ -329,30 +510,23 @@ class Rango extends ProviderClass {
 
   getToTokens(): ProviderToTokenResponse {
     const { tokens } = this.rangoMeta;
-    const supportedCRangoNames = Object.values(supportedNetworks).map(
-      (s) => s.name
-    );
-    const rangoToNetwork: Record<string, SupportedNetworkName> = {};
-    Object.keys(supportedNetworks).forEach((net) => {
-      rangoToNetwork[supportedNetworks[net].name] =
-        net as unknown as SupportedNetworkName;
-    });
 
-    tokens?.forEach((rangoToken) => {
-      // Unrecognised network
-      if (!supportedCRangoNames.includes(rangoToken.blockchain)) return;
+    for (let i = 0, len = tokens.length; i < len; i++) {
+      const token = tokens[i];
+      const supportedNetwork = supportedNetworkByRangoBlockchain.get(
+        token.blockchain
+      );
 
-      const network = rangoToNetwork[rangoToken.blockchain];
+      // Unrecognised network (Rango supports it but we don't)
+      if (!supportedNetwork) continue;
 
-      this.toTokens[network] ??= {};
-
-      const address = rangoToken.address || NATIVE_TOKEN_ADDRESS;
+      const address = token.address || NATIVE_TOKEN_ADDRESS;
       const lcaddress = address.toLowerCase() as Lowercase<string>;
-      const key: `${string}-${Lowercase<string>}` = `${rangoToken.blockchain}-${lcaddress}`;
+      const key: `${string}-${Lowercase<string>}` = `${token.blockchain}-${lcaddress}`;
       const swaplistToken = this.swaplistMap.get(key);
 
       let type: NetworkType;
-      switch (network) {
+      switch (supportedNetwork.name) {
         case SupportedNetworkName.Solana:
           type = NetworkType.Solana;
           break;
@@ -362,24 +536,26 @@ class Rango extends ProviderClass {
       }
 
       const toToken: TokenTypeTo = {
-        ...rangoToken,
+        ...token,
         address,
-        name: rangoToken.name || rangoToken.symbol,
-        logoURI: rangoToken.image,
+        name: token.name || token.symbol,
+        logoURI: token.image,
         type,
-        price: rangoToken.usdPrice,
+        price: token.usdPrice,
         cgId: swaplistToken?.token?.cgId,
-        symbol: rangoToken.symbol,
-        decimals: rangoToken.decimals,
+        symbol: token.symbol,
+        decimals: token.decimals,
         balance: undefined,
         rank: swaplistToken?.token?.rank,
         networkInfo: {
-          name: rangoToNetwork[rangoToken.blockchain],
-          isAddress: getIsAddressAsync(network),
+          name: supportedNetwork.name,
+          isAddress: getIsAddressAsync(supportedNetwork.name),
         },
       };
-      this.toTokens[network][address] = toToken;
-    });
+
+      this.toTokens[supportedNetwork.name] ??= {};
+      this.toTokens[supportedNetwork.name][address] = toToken;
+    }
 
     return this.toTokens;
   }
@@ -389,8 +565,11 @@ class Rango extends ProviderClass {
    * For cross-chain tokens like Ethereum (ETH) on the Binance Smart Chain (BSC) network,
    * it returns the corresponding symbol like WETH.
    */
-  private getSymbol(token: TokenType): string | undefined {
-    const { tokens } = this.rangoMeta;
+  private getRangoTokenSymbol(
+    token: TokenType,
+    rangoBlockchain: BlockchainMeta
+  ): string | undefined {
+    const { tokensByBlockchainAddress } = this.rangoMeta;
     if (this.isNativeToken(token.address)) return token.symbol;
     if (token.address == null) {
       console.warn(
@@ -399,10 +578,9 @@ class Rango extends ProviderClass {
       );
       return undefined;
     }
-    const lc = token.address.toLowerCase();
-    return Object.values(tokens || []).find(
-      (t) => t.address?.toLowerCase() === lc
-    )?.symbol;
+    const lcAddress = token.address.toLowerCase() as Lowercase<string>;
+    const key: `${string}-${Lowercase<string>}` = `${rangoBlockchain.name}-${lcAddress}`;
+    return tokensByBlockchainAddress.get(key)?.symbol;
   }
 
   private isNativeToken(address: string) {
@@ -430,79 +608,113 @@ class Rango extends ProviderClass {
     debug(
       "getRangoSwap",
       `Getting swap` +
-        `  srcToken=${options.fromToken.symbol}` +
-        `  dstToken=${options.toToken.symbol}` +
-        `  fromAddress=${options.fromAddress}` +
-        `  toAddress=${options.toAddress}` +
         `  fromNetwork=${this.network}` +
-        `  toNetwork=${options.toToken.networkInfo.name}`
+        `  toNetwork=${options.toToken.networkInfo.name}` +
+        `  fromToken=${options.fromToken.symbol}` +
+        `  toToken=${options.toToken.symbol}` +
+        `  fromAddress=${options.fromAddress}` +
+        `  toAddress=${options.toAddress}`
     );
 
     try {
       // Determine whether Enkrypt + Rango supports this swap
       abortable?.signal?.throwIfAborted();
 
-      // Do we support Rango on this network?
-      if (
-        !Rango.isSupported(
-          options.toToken.networkInfo.name as SupportedNetworkName,
-          blockchains
-        ) ||
-        !Rango.isSupported(this.network, blockchains)
-      ) {
+      // We must support Rango on the source network
+      // (note: probably redundant since we should always support rango on the source network if we got this far)
+      const fromNetworkInfo = supportedNetworkInfoByName.get(this.network);
+      if (!fromNetworkInfo) {
+        debug(
+          "getRangoSwap",
+          "No swap:" +
+            ` Enkrypt does not support Rango swap on the source network` +
+            `  fromNetwork=${this.network}`
+        );
+      }
+
+      // We must support Rango on the destination network
+      const toNetworkInfo = supportedNetworkInfoByName.get(
+        options.toToken.networkInfo.name as SupportedNetworkName
+      );
+      if (!toNetworkInfo) {
+        debug(
+          "getRangoSwap",
+          "No swap:" +
+            ` Enkrypt does not support Rango swap on the destination network` +
+            `  fromNetwork=${this.network}`
+        );
+      }
+
+      // Rango must support the source network
+      const fromRangoBlockchain = Rango.findRangoBlockchainForSupportedNetwork(
+        fromNetworkInfo,
+        blockchains
+      );
+      if (!fromRangoBlockchain?.enabled) {
         debug(
           "getRangoSwap",
           `No swap:` +
-            ` Enkrypt does not support Rango swap on the destination` +
-            ` network ${options.toToken.networkInfo.name}`
+            ` Rango does not support swap on the source network` +
+            `  fromNetwork=${this.network}` +
+            `  fromBlockchain=${fromRangoBlockchain.name}` +
+            `  enabled=${fromRangoBlockchain.enabled}`
         );
-        return Promise.resolve(null);
+        return null;
       }
+      const fromRangoBlockchainName = fromRangoBlockchain.name;
+
+      // Rango must support the destination network
+      const toRangoBlockchain = Rango.findRangoBlockchainForSupportedNetwork(
+        toNetworkInfo,
+        blockchains
+      );
+      if (!toRangoBlockchain?.enabled) {
+        debug(
+          "getRangoSwap",
+          `No swap:` +
+            ` Rango does not support swap on the destination network` +
+            `  toNetwork=${options.toToken.networkInfo.name}` +
+            `  toBlockchain=${toRangoBlockchain.name}` +
+            `  enabled=${toRangoBlockchain.enabled}`
+        );
+        return null;
+      }
+      const toRangoBlockchainName = toRangoBlockchain.name;
 
       // Does Rango support these tokens?
       const feeConfig = FEE_CONFIGS[this.name][meta.walletIdentifier];
 
-      /** Source token Rango blockchain name */
-      const fromBlockchain = blockchains.find((rangoBlockchain) =>
-        rangoChainIdsEq(
-          rangoBlockchain.chainId,
-          supportedNetworks[this.network].rangoChainId
-        )
-      )?.name;
-
-      /** Destination token Rango blockchain name */
-      const toBlockchain = blockchains.find((rangoBlockchain) =>
-        rangoChainIdsEq(
-          rangoBlockchain.chainId,
-          supportedNetworks[options.toToken.networkInfo.name].rangoChainId
-        )
-      )?.name;
-
       debug(
         "getRangoSwap",
         `Rango block chains ids` +
-          `  fromBlokchain=${fromBlockchain}` +
-          `  toBlockchain=${toBlockchain}`
+          `  fromRangoBlockchain=${fromRangoBlockchainName}` +
+          `  toRangoBlockchain=${toRangoBlockchainName}`
       );
 
       const fromTokenAddress = options.fromToken.address;
       const toTokenAddress = options.toToken.address;
 
       /** Source token symbol */
-      const fromSymbol = this.getSymbol(options.fromToken);
+      const fromRangoTokenSymbol = this.getRangoTokenSymbol(
+        options.fromToken,
+        fromRangoBlockchain
+      );
 
       /** Destination token symbol */
-      const toSymbol = this.getSymbol(options.toToken);
+      const toRangoTokenSymbol = this.getRangoTokenSymbol(
+        options.toToken,
+        toRangoBlockchain
+      );
 
       // If we can't get symbols for the tokens then we don't support them
-      if (!fromSymbol || !toSymbol) {
+      if (!fromRangoTokenSymbol || !toRangoTokenSymbol) {
         debug(
           "getRangoSwap",
           `No swap: No symbol for src token or dst token` +
-            `  srcTokenSymbol=${fromSymbol}` +
-            `  dstTokenSymbol=${toSymbol}`
+            `  fromTokenSymbol=${fromRangoTokenSymbol}` +
+            `  toTokenSymbol=${toRangoTokenSymbol}`
         );
-        return Promise.resolve(null);
+        return null;
       }
 
       // Enkrypt & Rango both likely support this swap (pair & networks)
@@ -518,13 +730,13 @@ class Rango extends ProviderClass {
           address: !this.isNativeToken(fromTokenAddress)
             ? fromTokenAddress
             : null,
-          blockchain: fromBlockchain,
-          symbol: fromSymbol,
+          blockchain: fromRangoBlockchainName,
+          symbol: fromRangoTokenSymbol,
         },
         to: {
           address: !this.isNativeToken(toTokenAddress) ? toTokenAddress : null,
-          blockchain: toBlockchain,
-          symbol: toSymbol,
+          blockchain: toRangoBlockchainName,
+          symbol: toRangoTokenSymbol,
         },
         amount: options.amount.toString(),
         fromAddress: options.fromAddress,
@@ -538,17 +750,17 @@ class Rango extends ProviderClass {
       debug(
         "getRangoSwap",
         `Requesting quote from rango sdk...` +
-          `  fromBlockchain=${fromBlockchain}` +
-          `  toBlockchain=${toBlockchain}` +
-          `  fromToken=${fromSymbol}` +
-          `  toToken=${toSymbol}` +
+          `  fromRangoBlockchain=${fromRangoBlockchainName}` +
+          `  toRangoBlockchain=${toRangoBlockchainName}` +
+          `  fromToken=${fromRangoTokenSymbol}` +
+          `  toToken=${toRangoTokenSymbol}` +
           `  fromAddress=${options.fromAddress}` +
           `  toAddress=${options.toAddress}` +
           `  amount=${options.amount.toString()}` +
           `  slippage=${slippage}` +
           `  referrerFee=${params.referrerFee}`
       );
-      const rangoSwapResponse = await rangoClient.swap(params);
+      const rangoSwapResponse = await rangoClient.swap(params, abortable);
       debug("getRangoSwap", `Received quote from rango sdk`);
 
       abortable?.signal?.throwIfAborted();
@@ -560,7 +772,7 @@ class Rango extends ProviderClass {
         // Rango experienced some kind of error or is unable to route the swap
         debug("getRangoSwap", `Rango swap SDK returned an error`);
         console.error("Rango swap SDK error:", rangoSwapResponse.error);
-        return Promise.resolve(null);
+        return null;
       }
 
       debug("getRangoSwap", `Rango swap SDK returned OK`);
@@ -702,10 +914,10 @@ class Rango extends ProviderClass {
                     sig.signature
                   ).toString("hex")}`;
                 }
-                warnMsg += `  fromBlockchain=${fromBlockchain}`;
-                warnMsg += `  toBlockchain=${toBlockchain}`;
-                warnMsg += `  fromToken=${fromSymbol}`;
-                warnMsg += `  toToken=${toSymbol}`;
+                warnMsg += `  fromRangoBlockchain=${fromRangoBlockchainName}`;
+                warnMsg += `  toRangoBlockchain=${toRangoBlockchainName}`;
+                warnMsg += `  fromToken=${fromRangoTokenSymbol}`;
+                warnMsg += `  toToken=${toRangoTokenSymbol}`;
                 warnMsg += `  fromAddress=${options.fromAddress}`;
                 warnMsg += `  toAddress=${options.toAddress}`;
                 warnMsg += `  amount=${options.amount.toString()}`;
@@ -731,10 +943,10 @@ class Rango extends ProviderClass {
                 else warnMsg += ` unsigned`;
                 warnMsg += ` legacy transaction,`;
                 warnMsg += ` dropping Rango swap transaction`;
-                warnMsg += `  fromBlockchain=${fromBlockchain}`;
-                warnMsg += `  toBlockchain=${toBlockchain}`;
-                warnMsg += `  fromToken=${fromSymbol}`;
-                warnMsg += `  toToken=${toSymbol}`;
+                warnMsg += `  fromRangoBlockchain=${fromRangoBlockchainName}`;
+                warnMsg += `  toRangoBlockchain=${toRangoBlockchainName}`;
+                warnMsg += `  fromToken=${fromRangoTokenSymbol}`;
+                warnMsg += `  toToken=${toRangoTokenSymbol}`;
                 warnMsg += `  fromAddress=${options.fromAddress}`;
                 warnMsg += `  toAddress=${options.toAddress}`;
                 warnMsg += `  amount=${options.amount.toString()}`;
@@ -795,7 +1007,14 @@ class Rango extends ProviderClass {
                 extractSignaturesFromRangoTransaction(rangoSwapResponse.tx);
 
               // Verify Rango signatures incase rango gives us invalid transaction signatures
-              debug("getRangoSwap", "Checking Rango signatures...");
+              debug(
+                "getRangoSwap",
+                `Checking Rango signatures...` +
+                  `  signatures=${thirdPartySignatures.length}`,
+                `  pubkeys=${thirdPartySignatures
+                  .map(({ pubkey }) => pubkey)
+                  .join(",")}`
+              );
               const signaturesAreValid =
                 checkSolanaVersionedTransactionSignatures(
                   versionedTx,
@@ -805,8 +1024,8 @@ class Rango extends ProviderClass {
                 let warnMsg = `Rango Solana signed versioned transaction has invalid Rango signatures,`;
                 warnMsg += `  dropping Rango swap transaction`;
                 for (
-                  let tpsigi = 0;
-                  tpsigi < thirdPartySignatures.length;
+                  let tpsigi = 0, tpsiglen = thirdPartySignatures.length;
+                  tpsigi < tpsiglen;
                   tpsigi++
                 ) {
                   const sig = thirdPartySignatures[tpsigi];
@@ -815,10 +1034,10 @@ class Rango extends ProviderClass {
                     sig.signature
                   ).toString("hex")}`;
                 }
-                warnMsg += `  fromBlockchain=${fromBlockchain}`;
-                warnMsg += `  toBlockchain=${toBlockchain}`;
-                warnMsg += `  fromToken=${fromSymbol}`;
-                warnMsg += `  toToken=${toSymbol}`;
+                warnMsg += `  fromRangoBlockchain=${fromRangoBlockchainName}`;
+                warnMsg += `  toRangoBlockchain=${toRangoBlockchainName}`;
+                warnMsg += `  fromToken=${fromRangoTokenSymbol}`;
+                warnMsg += `  toToken=${toRangoTokenSymbol}`;
                 warnMsg += `  fromAddress=${options.fromAddress}`;
                 warnMsg += `  toAddress=${options.toAddress}`;
                 warnMsg += `  amount=${options.amount.toString()}`;
@@ -829,7 +1048,7 @@ class Rango extends ProviderClass {
               }
 
               // Sometimes Rango gives us bad transactions @ 2024-09-25
-              // so we don't let them quote the user
+              // Simulate the transaction to check if it actually works so we don't use it to quote the user
               debug("getRangoSwap", "Simulating transaction...");
               const statusResult =
                 await checkExpectedSolanaVersionedTransactionStatus(
@@ -844,10 +1063,10 @@ class Rango extends ProviderClass {
                 else warnMsg += ` unsigned`;
                 warnMsg += ` versioned transaction,`;
                 warnMsg += ` dropping Rango swap transaction`;
-                warnMsg += `  fromBlockchain=${fromBlockchain}`;
-                warnMsg += `  toBlockchain=${toBlockchain}`;
-                warnMsg += `  fromToken=${fromSymbol}`;
-                warnMsg += `  toToken=${toSymbol}`;
+                warnMsg += `  fromRangoBlockchain=${fromRangoBlockchainName}`;
+                warnMsg += `  toRangoBlockchain=${toRangoBlockchainName}`;
+                warnMsg += `  fromToken=${fromRangoTokenSymbol}`;
+                warnMsg += `  toToken=${toRangoTokenSymbol}`;
                 warnMsg += `  fromAddress=${options.fromAddress}`;
                 warnMsg += `  toAddress=${options.toAddress}`;
                 warnMsg += `  amount=${options.amount.toString()}`;
@@ -863,7 +1082,7 @@ class Rango extends ProviderClass {
                 type: TransactionType.solana,
                 from: rangoSwapResponse.tx.from,
                 to: options.toToken.address,
-                kind: "legacy",
+                kind: "versioned",
                 serialized: Buffer.from(versionedTx.serialize()).toString(
                   "base64"
                 ),
@@ -912,14 +1131,12 @@ class Rango extends ProviderClass {
 
       return result;
     } catch (err) {
-      if (abortable?.signal?.aborted && err === abortable.signal.reason) {
-        // Aborted & error is the abort error
-        return null;
+      if (!abortable?.signal?.aborted) {
+        console.error(
+          `Error getting Rango swap, returning empty response (no swap)`,
+          err
+        );
       }
-      console.error(
-        `Error getting Rango swap, returning empty response (no swap)`,
-        err
-      );
       return null;
     }
   }
@@ -1206,7 +1423,9 @@ async function fetchRangoSwaplist(abortable?: {
       if (!res.ok) {
         let msg = await res
           .text()
-          .catch((err) => `! Failed to decode response text: ${String(err)}`);
+          .catch(
+            (err: Error) => `! Failed to decode response text: ${String(err)}`
+          );
         const len = msg.length;
         if (len > 512 + 10 + len.toString().length)
           msg = `${msg.slice(0, 512)}... (512/${len})`;
@@ -1375,11 +1594,12 @@ async function checkExpectedSolanaLegacyTransactionStatus(
   | { succeeds: true; error?: undefined }
   | { succeeds: false; error: TransactionError }
 > {
-  const retries = [0, 1_000, 2_000];
+  const retries = [0, 500, 1_000, 2_000];
   let retryidx = 0;
   let errref: undefined | { txerr: TransactionError };
   let success = false;
   while (!success) {
+    abortable?.signal?.throwIfAborted();
     if (retryidx >= retries.length) {
       return { succeeds: false, error: errref!.txerr };
     }
@@ -1396,6 +1616,7 @@ async function checkExpectedSolanaLegacyTransactionStatus(
           ` with updated block hash ${latestBlockHash.blockhash}...`
       );
       legacyTx.recentBlockhash = latestBlockHash.blockhash;
+      abortable?.signal?.throwIfAborted();
     }
     const sim = await conn.simulateTransaction(legacyTx);
     if (sim.value.err) {


### PR DESCRIPTION
- Enables Rango swap on Solana
- Fixes issues where Rango provides third party signatures and they don't get processed properly
- Fixes an issue where Rango Solana versioned transactions were sometimes parsed as legacy transactions
- Fixes issues where Rango transactions don't have adequate priority fees (fixed on Rango's end)
- Update Solana transaction block hashes where possible (not signed by third party) and necessary (too far behind) as close to signing as possible
- More descriptive error message where user sends swap transaction with expired block hash
- Minor performance improvements (using maps over arrays in some places)
- Minor correctness improvements? (matching tokens by blockchain and address instead of just address)
- Minor debug logging improvements
- Extra comment documentation
- Pass cancellation signals to Rango network calls
- Add more cancel points
- More descriptive naming of variables