### PR TITLE
Fix: Rango supported network check

### DIFF
--- a/packages/swap/src/providers/rango/index.ts
+++ b/packages/swap/src/providers/rango/index.ts
@@ -629,6 +629,7 @@ class Rango extends ProviderClass {
             ` Enkrypt does not support Rango swap on the source network` +
             `  fromNetwork=${this.network}`
         );
+        return null;
       }
 
       // We must support Rango on the destination network
@@ -642,6 +643,7 @@ class Rango extends ProviderClass {
             ` Enkrypt does not support Rango swap on the destination network` +
             `  fromNetwork=${this.network}`
         );
+        return null;
       }
 
       // Rango must support the source network

--- a/packages/swap/tests/zerox.test.ts
+++ b/packages/swap/tests/zerox.test.ts
@@ -25,10 +25,10 @@ describe("Zerox Provider", () => {
 
   if (process.env.CI) {
     // We need at-least one test otherwise vitest reports failure
-    it('No ZeroX swap tests in CI', function() {
-      expect(true).toBeTruthy()
-    })
-    return
+    it("No ZeroX swap tests in CI", function () {
+      expect(true).toBeTruthy();
+    });
+    return;
   }
 
   it(


### PR DESCRIPTION
Fixes a bug where Rango doesn't exit early if a network is not supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for unsupported source or destination networks in the swap functionality.
  - Improved debug logging for the swap process, providing better insights into network and token states.

- **Bug Fixes**
  - Refined error handling for Rango swap responses, ensuring appropriate logging and returning `null` in case of issues.

- **Tests**
  - Standardized formatting and descriptions in the Zerox provider test suite for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->