### PR TITLE
fix: remove tooltip when pasword is very strong

### DIFF
--- a/packages/extension/src/ui/action/components/password-input/components/password-input-strength.vue
+++ b/packages/extension/src/ui/action/components/password-input/components/password-input-strength.vue
@@ -51,7 +51,7 @@
     </p>
 
     <a
-      v-if="value.length > 0"
+      v-if="value.length > 0 && strength != PasswordStrength.veryStrong"
       class="password-input-strength__help visible"
       @mouseenter="toggleTooltip"
       @mouseleave="toggleTooltip"
@@ -68,13 +68,7 @@
         <h4 v-if="strength == PasswordStrength.medium" class="medium">
           {{ toolTipInfo }}
         </h4>
-        <h4
-          v-if="
-            strength == PasswordStrength.strong ||
-            strength == PasswordStrength.veryStrong
-          "
-          class="strong"
-        >
+        <h4 v-if="strength == PasswordStrength.strong" class="strong">
           {{ toolTipInfo }}
         </h4>
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved password strength feedback with a streamlined help tooltip.
	- Help tooltip now displays only for "strong" passwords, enhancing clarity for users.

- **Bug Fixes**
	- Removed unnecessary help link for "very strong" passwords to reduce confusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->