### PR TITLE
fix: remove etherscan activity for bsc

### DIFF
--- a/packages/extension/src/providers/ethereum/networks/arb-nova.ts
+++ b/packages/extension/src/providers/ethereum/networks/arb-nova.ts
@@ -3,6 +3,7 @@ import { CoingeckoPlatform, NetworkNames } from '@enkryptcom/types';
 import { EvmNetwork, EvmNetworkOptions } from '../types/evm-network';
 import assetsInfoHandler from '@/providers/ethereum/libs/assets-handlers/assetinfo-mew';
 import shNFTHandler from '@/libs/nft-handlers/simplehash';
+import wrapActivityHandler from '@/libs/activity-state/wrap-activity-handler';
 
 const arbNovaOptions: EvmNetworkOptions = {
   name: NetworkNames.ArbitrumNova,
@@ -20,7 +21,7 @@ const arbNovaOptions: EvmNetworkOptions = {
   coingeckoPlatform: CoingeckoPlatform.ArbitrumNova,
   assetsInfoHandler,
   NFTHandler: shNFTHandler,
-  activityHandler: () => Promise.resolve([]),
+  activityHandler: wrapActivityHandler(() => Promise.resolve([])),
 };
 
 const arb = new EvmNetwork(arbNovaOptions);

--- a/packages/extension/src/providers/ethereum/networks/bsc.ts
+++ b/packages/extension/src/providers/ethereum/networks/bsc.ts
@@ -2,6 +2,8 @@ import icon from './icons/bsc.svg';
 import { CoingeckoPlatform, NetworkNames } from '@enkryptcom/types';
 import { EvmNetwork, EvmNetworkOptions } from '../types/evm-network';
 import assetsInfoHandler from '@/providers/ethereum/libs/assets-handlers/assetinfo-mew';
+import { EtherscanActivity } from '../libs/activity-handlers';
+import wrapActivityHandler from '@/libs/activity-state/wrap-activity-handler';
 import shNFTHandler from '@/libs/nft-handlers/simplehash';
 
 const bscOptions: EvmNetworkOptions = {
@@ -21,7 +23,7 @@ const bscOptions: EvmNetworkOptions = {
   basePath: "m/44'/714'",
   NFTHandler: shNFTHandler,
   assetsInfoHandler,
-  activityHandler: () => Promise.resolve([]),
+  activityHandler: wrapActivityHandler(() => Promise.resolve([])),
 };
 
 const bsc = new EvmNetwork(bscOptions);

--- a/packages/extension/src/providers/ethereum/networks/bsc.ts
+++ b/packages/extension/src/providers/ethereum/networks/bsc.ts
@@ -2,8 +2,6 @@ import icon from './icons/bsc.svg';
 import { CoingeckoPlatform, NetworkNames } from '@enkryptcom/types';
 import { EvmNetwork, EvmNetworkOptions } from '../types/evm-network';
 import assetsInfoHandler from '@/providers/ethereum/libs/assets-handlers/assetinfo-mew';
-import { EtherscanActivity } from '../libs/activity-handlers';
-import wrapActivityHandler from '@/libs/activity-state/wrap-activity-handler';
 import shNFTHandler from '@/libs/nft-handlers/simplehash';
 
 const bscOptions: EvmNetworkOptions = {
@@ -23,7 +21,7 @@ const bscOptions: EvmNetworkOptions = {
   basePath: "m/44'/714'",
   NFTHandler: shNFTHandler,
   assetsInfoHandler,
-  activityHandler: wrapActivityHandler(EtherscanActivity),
+  activityHandler: () => Promise.resolve([]),
 };
 
 const bsc = new EvmNetwork(bscOptions);

--- a/packages/extension/src/providers/ethereum/networks/holesky.ts
+++ b/packages/extension/src/providers/ethereum/networks/holesky.ts
@@ -1,6 +1,7 @@
 import icon from './icons/eth.svg';
 import { NetworkNames } from '@enkryptcom/types';
 import { EvmNetwork, EvmNetworkOptions } from '../types/evm-network';
+import wrapActivityHandler from '@/libs/activity-state/wrap-activity-handler';
 
 const holeskyOptions: EvmNetworkOptions = {
   name: NetworkNames.Holesky,
@@ -14,7 +15,7 @@ const holeskyOptions: EvmNetworkOptions = {
   currencyNameLong: 'Holesky',
   node: 'wss://nodes.mewapi.io/ws/holesky',
   icon,
-  activityHandler: () => Promise.resolve([]),
+  activityHandler: wrapActivityHandler(() => Promise.resolve([])),
 };
 
 const holesky = new EvmNetwork(holeskyOptions);

--- a/packages/extension/src/providers/ethereum/networks/op-bnb.ts
+++ b/packages/extension/src/providers/ethereum/networks/op-bnb.ts
@@ -3,6 +3,7 @@ import { CoingeckoPlatform, NetworkNames } from '@enkryptcom/types';
 import { EvmNetwork, EvmNetworkOptions } from '../types/evm-network';
 import assetsInfoHandler from '@/providers/ethereum/libs/assets-handlers/assetinfo-mew';
 import shNFTHandler from '@/libs/nft-handlers/simplehash';
+import wrapActivityHandler from '@/libs/activity-state/wrap-activity-handler';
 
 const opBnbOptions: EvmNetworkOptions = {
   name: NetworkNames.OpBNB,
@@ -20,7 +21,7 @@ const opBnbOptions: EvmNetworkOptions = {
   coingeckoPlatform: CoingeckoPlatform.OpBNB,
   assetsInfoHandler,
   NFTHandler: shNFTHandler,
-  activityHandler: () => Promise.resolve([]),
+  activityHandler: wrapActivityHandler(() => Promise.resolve([])),
 };
 
 const op = new EvmNetwork(opBnbOptions);

--- a/packages/extension/src/providers/ethereum/networks/palm.ts
+++ b/packages/extension/src/providers/ethereum/networks/palm.ts
@@ -2,6 +2,7 @@ import icon from './icons/palm.svg';
 import { NetworkNames } from '@enkryptcom/types';
 import { EvmNetwork, EvmNetworkOptions } from '../types/evm-network';
 import shNFTHandler from '@/libs/nft-handlers/simplehash';
+import wrapActivityHandler from '@/libs/activity-state/wrap-activity-handler';
 
 // Palm network has an API but it seems broken (DNS won't resolve)
 // @see https://palm.chainlens.com/api/swagger-ui/index.html
@@ -20,7 +21,7 @@ const palmNetworkOptions: EvmNetworkOptions = {
   icon,
   coingeckoID: 'palm-ai',
   NFTHandler: shNFTHandler,
-  activityHandler: () => Promise.resolve([]),
+  activityHandler: wrapActivityHandler(() => Promise.resolve([])),
 };
 
 const palmNetwork = new EvmNetwork(palmNetworkOptions);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Simplified activity handling for the Binance Smart Chain network, now returning a static response.
	- Enhanced activity handling for Arb Nova, Holesky, opBNB, and Palm networks by integrating a new management function.

- **Bug Fixes**
	- Resolved issues related to activity fetching by providing an empty array response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->