### PR TITLE
[FIX] Asset Balances Not Showing for Rootstock

### DIFF
--- a/packages/extension/src/providers/ethereum/libs/assets-handlers/assetinfo-mew.ts
+++ b/packages/extension/src/providers/ethereum/libs/assets-handlers/assetinfo-mew.ts
@@ -72,6 +72,7 @@ const supportedNetworks: Record<SupportedNetworkNames, SupportedNetwork> = {
   [NetworkNames.Rootstock]: {
     tbName: 'rsk',
     cgPlatform: CoingeckoPlatform.Rootstock,
+    bsEndpoint: true,
   },
   [NetworkNames.Arbitrum]: {
     tbName: 'arb',


### PR DESCRIPTION
## Description

This PR fixes the issue of assets balances not showing when Rootstock network selected. 

## Bug Screen

- Home screen balances not showing
- Send screen not working because balances not loading

<img width="796" alt="bug" src="https://github.com/user-attachments/assets/835056ad-5b1f-4aa2-bf20-6d10d9ded7a3" />

## Why 

Following API's are not returning balance for Rootstock network due to this reason Rootstock assets balances are not showing on home screen and send screen. 

```
const API_ENPOINT = 'https://tokenbalance.mewapi.io/';
const API_ENPOINT2 = 'https://partners.mewapi.io/balances/';
```

## Suggested solutions

Enabling rootstock in above api's or enabling the blockscout url for Rootstock could be solution. Feel free to suggest or apply  if there is any other solution to fix this issue.

## After enabling the blockscout url
<img width="792" alt="Screenshot 2025-02-10 at 3 48 10 PM" src="https://github.com/user-attachments/assets/14b2fd80-d008-4439-9844-5058527e4a81" />






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated token balance retrieval for users on Rootstock, SyscoinNEVM, and Rollux networks. The system now employs an alternative data source to fetch balance information, ensuring improved accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->