### PR TITLE
[FIX] Total balance not updated when withdrawal completes

### DIFF
--- a/packages/extension/src/providers/ethereum/ui/send-transaction/verify-transaction/index.vue
+++ b/packages/extension/src/providers/ethereum/ui/send-transaction/verify-transaction/index.vue
@@ -219,6 +219,7 @@ const sendAction = async () => {
               web3
                 .sendSignedTransaction(bufferToHex(signedTx.serialize()))
                 .on('transactionHash', onHash)
+                .on('receipt', () => router.go(0))
                 .on('error', (error: any) => {
                   txActivity.status = ActivityStatus.failed;
                   activityState.addActivities([txActivity], {


### PR DESCRIPTION
## Description
This PR fixes the issue of total balance not refreshing after tx confirms. Due to this issue the individual and total balances does not match. When the withdrawal is processed, it is needed to refresh in order to see the total balance update.

Tested this on couple of EVM chains, it's happening on all EVM chains. 

## Snapshots
<img width="391" alt="Screenshot 2025-03-14 at 3 15 21 PM (1)" src="https://github.com/user-attachments/assets/e5a05f6a-eabf-4cc7-859f-6bf85c4a2b76" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The application now automatically refreshes the page once a transaction receipt is received, ensuring you always see the latest transaction status.
  - Error handling behavior remains active, continuing to notify you of any issues during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->