### PR TITLE
Update Rootstock node url

### DIFF
--- a/packages/extension/src/providers/ethereum/networks/rsk.ts
+++ b/packages/extension/src/providers/ethereum/networks/rsk.ts
@@ -20,7 +20,7 @@ const rootstockOptions: EvmNetworkOptions = {
   isTestNetwork: false,
   currencyName: 'RBTC',
   currencyNameLong: 'Rootstock',
-  node: 'wss://public-node.rsk.co/websocket',
+  node: 'wss://nodes.mewapi.io/ws/rsk',
   icon,
   basePath: "m/44'/137'/0'/0",
   coingeckoID: CoingeckoPlatform.Rootstock,


### PR DESCRIPTION
## Description

This PR updates Rootstock node url to `wss://nodes.mewapi.io/ws/rsk` which uses RPC API. 

## Why

The public websocket url (wss://public-node.rsk.co/websocket) will be depricated in the favor of [RPC API](https://dashboard.rpc.rootstock.io/). 

