### PR TITLE
Fixing the coinGecko id bug ifor Arbitrum

### DIFF
--- a/packages/swap/src/common/supportedNetworks.ts
+++ b/packages/swap/src/common/supportedNetworks.ts
@@ -91,7 +91,8 @@ const NetworkDetails: Record<SupportedNetworkName, NetworkInfo> = {
   },
   [SupportedNetworkName.Arbitrum]: {
     id: SupportedNetworkName.Arbitrum,
-    cgId: "ethereum",
+    cgId: "arbitrum",
+    // before it was cgId: "ethereum",
     decimals: 18,
     logoURI:
       "https://assets.coingecko.com/coins/images/16547/large/photo_2023-03-29_21.47.00.jpeg",


### PR DESCRIPTION
Yo ther was this bug comment about "Loading assets failed. Please try again later #674
", so i thought scanned  through the files and did some research and this might be happening because of the wrong  coingecko id of arbitrum being written there, the cgId is arbitrum itself!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the network identifier for Arbitrum to ensure accurate network representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->