### PR TITLE
Enable `Changelly` swaps on Rootstock

### DIFF
--- a/packages/extension/src/providers/ethereum/libs/transaction/index.ts
+++ b/packages/extension/src/providers/ethereum/libs/transaction/index.ts
@@ -105,7 +105,7 @@ class Transaction {
         feeHistory: {} as FeeHistoryResult,
       }));
     // Gets the number of transactions that they will have sent by the next pending block
-    const nonce = await this.web3.getTransactionCount(this.tx.from, 'pending');
+    const nonce = await this.web3.getTransactionCount(this.tx.from.toLowerCase(), 'pending'); // web3 rejects rootstock checksum addr so use lowercase addr
     if (!isFeeMarketNetwork) {
       // Legacy transaction
       const gasPrice = await this.web3.getGasPrice();

--- a/packages/swap/src/providers/changelly/index.ts
+++ b/packages/swap/src/providers/changelly/index.ts
@@ -133,7 +133,7 @@ class Changelly extends ProviderClass {
 
       if (
         cur.enabledFrom &&
-        cur.fixRateEnabled &&
+        (cur.fixRateEnabled || cur.protocol === "RBTC") && // Allow RBTC as native currency for gas fees and swaps
         cur.token &&
         changellyToNetwork[cur.blockchain] === this.network
       ) {


### PR DESCRIPTION
## Description

This PR adds minor fixes to enable `Changelly` swaps on Rootstock. Currently fix rate is enabled for `rif` token but for `rbtc` the fix rate is not enabled. So suggesting if it's acceptable to bypass rbtc fix rate and include it for changelly swaps. 

# Demo

<img width="791" alt="Screenshot 2025-06-18 at 12 26 19 PM" src="https://github.com/user-attachments/assets/f686a12a-2b63-46b6-8cf7-3aa11d496cc1" />
<img width="306" alt="Screenshot 2025-06-18 at 12 27 44 PM" src="https://github.com/user-attachments/assets/ed86ad30-04f6-4933-9833-70e185ef672f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved compatibility with Rootstock checksum addresses when retrieving transaction counts by converting addresses to lowercase.
	- Expanded token support in swaps to include tokens using the "RBTC" protocol, allowing them to be used as native currency for gas fees and swaps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->