### PR TITLE
FIX - Hide RBTC from swaps

### DIFF
--- a/packages/extension/src/ui/action/views/swap/components/swap-assets-select-list.vue
+++ b/packages/extension/src/ui/action/views/swap/components/swap-assets-select-list.vue
@@ -50,9 +50,11 @@ const BaseTokenAssets = computed(() => {
       }),
       TokenType: asset,
     };
-    basetokens.push(
-      TokenTypeMap[asset.address || NATIVE_TOKEN_ADDRESS].baseToken,
-    );
+    if (asset.symbol !== "RBTC") {
+      basetokens.push(
+            TokenTypeMap[asset.address || NATIVE_TOKEN_ADDRESS].baseToken,
+          );
+    }
   });
   return basetokens;
 });

--- a/packages/extension/src/ui/action/views/swap/index.vue
+++ b/packages/extension/src/ui/action/views/swap/index.vue
@@ -282,7 +282,7 @@ onMounted(async () => {
       });
       swapFromTokens = {
         all: swapFromTokens.all.filter(t => {
-          if (tokensWithBalance[t.address]) {
+          if (tokensWithBalance[t.address] && t.symbol !== "RBTC") {
             t.balance = toBN(tokensWithBalance[t.address]);
             return true;
           }


### PR DESCRIPTION
## Description
This PR hides RBTC from list of assets shown in swap screen as fix rate is not enabled for RBTC. Just enable swap for RIF only. 