### PR TITLE
[HOT FIX] Fix blockscout urls

### DIFF
--- a/packages/extension/src/providers/ethereum/libs/activity-handlers/providers/etherscan/configs.ts
+++ b/packages/extension/src/providers/ethereum/libs/activity-handlers/providers/etherscan/configs.ts
@@ -11,9 +11,9 @@ const NetworkEndpoints: Record<string, string> = {
   [NetworkNames.ShidenEVM]: 'https://blockscout.com/shiden/api?',
   [NetworkNames.Optimism]: 'https://api.etherscan.io/v2/api?chainid=10&',
   [NetworkNames.EdgeEVM]: 'https://edgscan.live/api?',
-  [NetworkNames.Rootstock]: 'https://blockscout.com/rsk/mainnet/api?',
+  [NetworkNames.Rootstock]: 'https://blockscout.com/rsk/mainnet/',
   [NetworkNames.RootstockTestnet]:
-    'https://rootstock-testnet.blockscout.com/api?',
+    'https://rootstock-testnet.blockscout.com/',
   [NetworkNames.SkaleBlockBrawlers]:
     'https://frayed-decent-antares.explorer.mainnet.skalenodes.com/api?',
   [NetworkNames.SkaleCalypso]:

--- a/packages/extension/src/providers/ethereum/libs/activity-handlers/providers/etherscan/index.ts
+++ b/packages/extension/src/providers/ethereum/libs/activity-handlers/providers/etherscan/index.ts
@@ -21,7 +21,7 @@ const getAddressActivity = async (
   return cacheFetch(
     {
       // Note: would like to add offset=50 (i.e. results per page) but it seems to cause polygon API to hang
-      url: `${endpoint}module=account&action=txlist&address=${address}&sort=desc`,
+      url: `${endpoint}${endpoint.includes('blockscout.com') ? 'api?': ''}module=account&action=txlist&address=${address}&sort=desc`,
       headers,
     },
     TTL,


### PR DESCRIPTION
## Description

The blockscout url change in this commit: https://github.com/enkryptcom/enKrypt/commit/c8edc6e6a9e5f21c945cbd9a4e0b60f264c2acd4 is breaking the url format and blockscout api is not working for the networks using blockscout api.

## Bug screentshot

<img width="443" height="364" alt="image (11)" src="https://github.com/user-attachments/assets/4f40fded-e947-400f-9c4e-3e05caa04ca1" />
<img width="2286" height="1370" alt="Screenshot 2025-10-07 at 8 30 47 PM" src="https://github.com/user-attachments/assets/b7f6c5cd-c119-4332-afac-b3f1ff775a23" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed activity feed issues on Rootstock and Rootstock Testnet by updating network endpoints, preventing failed or missing transactions.
  - Restored compatibility with Blockscout-based explorers by correctly handling api? path segments, ensuring successful activity requests.
  - Improves reliability and consistency of address activity across supported networks with no UI changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->