### PR TITLE
[Fix] Fix Blockscout response mapping for token address

### DIFF
--- a/packages/extension/src/providers/ethereum/libs/assets-handlers/blockscout.ts
+++ b/packages/extension/src/providers/ethereum/libs/assets-handlers/blockscout.ts
@@ -11,7 +11,7 @@ interface TokenBalanceType {
 
 interface TokenResponseItem {
   token: {
-    address: string;
+    address_hash: string;
     decimals: string;
     name: string;
     symbol: string;
@@ -57,12 +57,12 @@ const getBlockscoutBalances = (
         ? tokenResponse.items
             .filter(
               item =>
-                item?.token?.address &&
-                typeof item.token.address === 'string' &&
+                item?.token?.address_hash &&
+                typeof item.token.address_hash === 'string' &&
                 item.value !== undefined,
             )
             .map(item => ({
-              token: item.token.address.toLowerCase(),
+              token: item.token.address_hash.toLowerCase(),
               quantity: item.value,
             }))
         : [];


### PR DESCRIPTION
## Description
This api fixes the token response mapping for token addresses.

API: https://rootstock.blockscout.com/api/v2/addresses/0xA78C937844b27Bec024f042DCbe5b85D2B7344F6/tokens?type=ERC-20

In the response the token address is coming in the field: address_hash. Previsouly it was coming in address field. This is a change from blockscout side in fields mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Blockscout token address handling to ensure proper token identification and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->