### PR TITLE
fix: extraword showing

### DIFF
--- a/packages/extension/src/ui/action/views/settings/views/settings-recovery/index.vue
+++ b/packages/extension/src/ui/action/views/settings/views/settings-recovery/index.vue
@@ -67,7 +67,7 @@ const secondSet = computed(() => {
 });
 
 const hasExtraWord = computed(() => {
-  return props.mnemonic.extraWord !== '';
+  return props.mnemonic.extraWord && props.mnemonic.extraWord !== '';
 });
 </script>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the rendering condition for the "Extra Word" section in the Settings/Recovery view to properly display only when an extra word is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->