### PR TITLE
fix(bitcoin): support sending to taproot (bc1p) addresses

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@amplitude/analytics-browser": "^2.42.4",
+    "@bitcoinerlab/secp256k1": "^1.2.0",
     "@enkryptcom/extension-bridge": "workspace:^",
     "@enkryptcom/hw-wallets": "workspace:^",
     "@enkryptcom/keyring": "workspace:^",

--- a/packages/extension/src/providers/bitcoin/libs/init-ecc.ts
+++ b/packages/extension/src/providers/bitcoin/libs/init-ecc.ts
@@ -1,0 +1,13 @@
+import * as ecc from '@bitcoinerlab/secp256k1';
+import { initEccLib } from 'bitcoinjs-lib';
+
+/**
+ * bitcoinjs-lib does not bundle an elliptic curve implementation. Anything
+ * taproot related throws `No ECC Library provided` until one is registered,
+ * which makes `address.toOutputScript` reject every `bc1p...` address and, in
+ * turn, makes taproot recipients look invalid and unspendable to.
+ *
+ * Importing this module for its side effect registers the curve once. Import it
+ * from any module that validates addresses or builds output scripts.
+ */
+initEccLib(ecc);

--- a/packages/extension/src/providers/bitcoin/libs/utils.ts
+++ b/packages/extension/src/providers/bitcoin/libs/utils.ts
@@ -1,3 +1,4 @@
+import './init-ecc';
 import { BitcoinNetworkInfo, HaskoinUnspentType } from '../types';
 import { address as BTCAddress } from 'bitcoinjs-lib';
 import { GasPriceTypes } from '@/providers/common/types';

--- a/packages/extension/src/providers/bitcoin/tests/bitcoin.address.validation.test.ts
+++ b/packages/extension/src/providers/bitcoin/tests/bitcoin.address.validation.test.ts
@@ -1,0 +1,89 @@
+// @vitest-environment node
+//
+// bitcoinjs-lib verifies an ECC library by feeding it `Buffer.from(...)` test
+// vectors, and @noble/curves rejects anything that is not a `Uint8Array`. Under
+// the default jsdom environment those two come from different realms, so the
+// `instanceof` check fails and `initEccLib` throws even though the library is
+// fine. In a browser there is a single realm and the bundled Buffer polyfill
+// extends that realm's Uint8Array, so this only affects the test harness.
+import { describe, it, expect } from 'vitest';
+import bitcoinNetworks from '../networks';
+import { isAddress } from '../libs/utils';
+import {
+  calculateSizeBasedOnType,
+  getOutputCounterForAddress,
+} from '../ui/libs/tx-size';
+import { PaymentType } from '../types/bitcoin-network';
+
+const bitcoin = bitcoinNetworks.bitcoin.networkInfo;
+const litecoin = bitcoinNetworks.litecoin.networkInfo;
+
+// BIP86 test vector
+const TAPROOT =
+  'bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr';
+const NATIVE_SEGWIT = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
+const P2SH = '3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy';
+const P2PKH = '1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2';
+const P2WSH = 'bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3';
+
+describe('Should validate bitcoin recipient addresses', () => {
+  it('should accept taproot addresses', () => {
+    expect(isAddress(TAPROOT, bitcoin)).to.be.eq(true);
+  });
+
+  it('should accept every other standard mainnet address type', () => {
+    expect(isAddress(NATIVE_SEGWIT, bitcoin)).to.be.eq(true);
+    expect(isAddress(P2WSH, bitcoin)).to.be.eq(true);
+    expect(isAddress(P2SH, bitcoin)).to.be.eq(true);
+    expect(isAddress(P2PKH, bitcoin)).to.be.eq(true);
+  });
+
+  it('should reject malformed addresses and addresses from another network', () => {
+    expect(isAddress('not an address', bitcoin)).to.be.eq(false);
+    expect(isAddress('', bitcoin)).to.be.eq(false);
+    // valid taproot address, wrong network
+    expect(isAddress(TAPROOT, litecoin)).to.be.eq(false);
+    // checksum broken on the last character
+    expect(isAddress(`${TAPROOT.slice(0, -1)}p`, bitcoin)).to.be.eq(false);
+  });
+});
+
+describe('Should size outputs by their address type', () => {
+  it('should classify bech32 and bech32m outputs', () => {
+    expect(getOutputCounterForAddress(TAPROOT)).to.be.eq('p2tr_output_count');
+    expect(getOutputCounterForAddress(NATIVE_SEGWIT)).to.be.eq(
+      'p2wpkh_output_count',
+    );
+    expect(getOutputCounterForAddress(P2WSH)).to.be.eq('p2wsh_output_count');
+  });
+
+  it('should fall back to the account type for anything else', () => {
+    expect(getOutputCounterForAddress(P2SH)).to.be.eq(undefined);
+    expect(getOutputCounterForAddress(P2PKH)).to.be.eq(undefined);
+    expect(getOutputCounterForAddress('')).to.be.eq(undefined);
+  });
+
+  it('should charge for the larger taproot output', () => {
+    const toSegwit = calculateSizeBasedOnType(1, 2, PaymentType.P2WPKH, [
+      NATIVE_SEGWIT,
+    ]);
+    const toTaproot = calculateSizeBasedOnType(1, 2, PaymentType.P2WPKH, [
+      TAPROOT,
+    ]);
+    // P2TR_OUT_SIZE (43) - P2WPKH_OUT_SIZE (31)
+    expect(toTaproot - toSegwit).to.be.eq(12);
+  });
+
+  it('should size unknown outputs as the account type, as before', () => {
+    const withoutAddresses = calculateSizeBasedOnType(1, 2, PaymentType.P2WPKH);
+    expect(
+      calculateSizeBasedOnType(1, 2, PaymentType.P2WPKH, [NATIVE_SEGWIT]),
+    ).to.be.eq(withoutAddresses);
+    expect(calculateSizeBasedOnType(1, 2, PaymentType.P2WPKH, [''])).to.be.eq(
+      withoutAddresses,
+    );
+    expect(calculateSizeBasedOnType(1, 2, PaymentType.P2WPKH, [P2SH])).to.be.eq(
+      withoutAddresses,
+    );
+  });
+});

--- a/packages/extension/src/providers/bitcoin/ui/libs/signer.ts
+++ b/packages/extension/src/providers/bitcoin/ui/libs/signer.ts
@@ -1,3 +1,4 @@
+import '../../libs/init-ecc';
 import { InternalMethods, InternalOnMessageResponse } from '@/types/messenger';
 import { SignerTransactionOptions, SignerMessageOptions } from '../types';
 import sendUsingInternalMessengers from '@/libs/messenger/internal-messenger';

--- a/packages/extension/src/providers/bitcoin/ui/libs/tx-size.ts
+++ b/packages/extension/src/providers/bitcoin/ui/libs/tx-size.ts
@@ -1,6 +1,7 @@
 // https://github.com/jlopp/bitcoin-transaction-size-calculator/blob/master/index.html
 
 import { toBN } from 'web3-utils';
+import { address as BTCAddress } from 'bitcoinjs-lib';
 import { PaymentType } from '../../types/bitcoin-network';
 
 enum InputScriptType {
@@ -234,16 +235,52 @@ const calculateSize = (
     txWeight,
   };
 };
+/**
+ * Bucket an output address into the counter `calculateSize` uses for it.
+ *
+ * Only bech32/bech32m outputs are classified. Those are the ones whose size
+ * differs enough from the account's own output type to matter: a P2TR or P2WSH
+ * output is 43 vB against 31 vB for P2WPKH, which is the difference between a
+ * transaction relaying and being dropped for paying under the minimum fee rate.
+ * Anything else falls back to the account's own type, which is at most 3 vB out.
+ */
+const getOutputCounterForAddress = (
+  address: string,
+): keyof calcOutputType | undefined => {
+  let decoded: { version: number; data: Buffer };
+  try {
+    decoded = BTCAddress.fromBech32(address);
+  } catch {
+    return undefined;
+  }
+  if (decoded.version === 0) {
+    if (decoded.data.length === 20) return 'p2wpkh_output_count';
+    if (decoded.data.length === 32) return 'p2wsh_output_count';
+  } else if (decoded.version === 1 && decoded.data.length === 32) {
+    return 'p2tr_output_count';
+  }
+  return undefined;
+};
+
+/**
+ * `outputAddresses` describes the outputs that are already known, in order. Any
+ * output without a matching entry — the change output, or a recipient address
+ * that is still being typed — is sized as the account's own payment type.
+ */
 const calculateSizeBasedOnType = (
   numInputs: number,
   numOutputs: number,
   type: PaymentType,
+  outputAddresses: string[] = [],
 ): number => {
+  const defaultCounter: keyof calcOutputType =
+    type === PaymentType.P2PKH ? 'p2pkh_output_count' : 'p2wpkh_output_count';
   const output: calcOutputType = {};
-  if (type === PaymentType.P2PKH) {
-    output.p2pkh_output_count = numOutputs;
-  } else {
-    output.p2wpkh_output_count = numOutputs;
+  for (let i = 0; i < numOutputs; i++) {
+    const counter =
+      (outputAddresses[i] && getOutputCounterForAddress(outputAddresses[i])) ||
+      defaultCounter;
+    output[counter] = (output[counter] ?? 0) + 1;
   }
   const size = calculateSize(
     {
@@ -257,4 +294,9 @@ const calculateSizeBasedOnType = (
   );
   return type === PaymentType.P2PKH ? size.txBytes : size.txVBytes;
 };
-export { InputScriptType, calculateSize, calculateSizeBasedOnType };
+export {
+  InputScriptType,
+  calculateSize,
+  calculateSizeBasedOnType,
+  getOutputCounterForAddress,
+};

--- a/packages/extension/src/providers/bitcoin/ui/send-transaction/index.vue
+++ b/packages/extension/src/providers/bitcoin/ui/send-transaction/index.vue
@@ -279,7 +279,7 @@ const nativeBalanceAfterTransaction = computed(() => {
 
 const setTransactionFees = (byteSize: number) => {
   const nativeVal = selectedAsset.value.price || '0';
-  getGasCostValues(
+  return getGasCostValues(
     props.network as BitcoinNetwork,
     byteSize,
     nativeVal,
@@ -294,16 +294,26 @@ const setBaseCosts = () => {
   });
 };
 
+/**
+ * The recipient output is sized from `addressTo` so that sending to an address
+ * type larger than our own — a taproot one, say — is not underpaid. The change
+ * output has no entry and is sized as our own payment type.
+ */
+const updateTransactionFees = () => {
+  const txSize = calculateSizeBasedOnType(
+    accountUTXOs.value.length + (isSendToken.value ? 0 : 1),
+    2,
+    (props.network as BitcoinNetwork).networkInfo.paymentType,
+    [addressTo.value],
+  );
+  return setTransactionFees(Math.ceil(txSize));
+};
+
 const updateUTXOs = async () => {
   const api = (await props.network.api()) as BitcoinAPI;
   return api.getUTXOs(addressFrom.value).then(utxos => {
     accountUTXOs.value = utxos;
-    const txSize = calculateSizeBasedOnType(
-      accountUTXOs.value.length + (isSendToken.value ? 0 : 1),
-      2,
-      (props.network as BitcoinNetwork).networkInfo.paymentType,
-    );
-    setTransactionFees(Math.ceil(txSize));
+    return updateTransactionFees();
   });
 };
 
@@ -367,6 +377,12 @@ watch([addressFrom], () => {
   if (addressFrom.value) {
     fetchAssets().then(setBaseCosts);
   }
+});
+
+watch([addressTo], () => {
+  updateTransactionFees().then(() => {
+    if (isMaxSelected.value) setMaxValue();
+  });
 });
 
 const isOpenSelectContactFrom = ref<boolean>(false);

--- a/packages/extension/src/ui/action/views/swap/libs/bitcoin-gasvals.ts
+++ b/packages/extension/src/ui/action/views/swap/libs/bitcoin-gasvals.ts
@@ -15,6 +15,7 @@ export const getBitcoinGasVals = async (
     tx.inputs.length,
     2,
     (network as BitcoinNetwork).networkInfo.paymentType,
+    tx.outputs.map(output => output.address),
   );
   return getGasCostValues(
     network as BitcoinNetwork,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,6 +1726,7 @@ __metadata:
   resolution: "@enkryptcom/extension@workspace:packages/extension"
   dependencies:
     "@amplitude/analytics-browser": "npm:^2.42.4"
+    "@bitcoinerlab/secp256k1": "npm:^1.2.0"
     "@crxjs/vite-plugin": "npm:^2.4.0"
     "@enkryptcom/extension-bridge": "workspace:^"
     "@enkryptcom/hw-wallets": "workspace:^"


### PR DESCRIPTION
## Problem

Taproot addresses are rejected as invalid in the Bitcoin send screen. Pasting any `bc1p...` address turns the input red and leaves the Send button disabled, and there is no setting that changes it.

## Root cause

`isAddress` in `providers/bitcoin/libs/utils.ts` validates by round-tripping through `bitcoinjs-lib`:

```ts
const isAddress = (address: string, network: BitcoinNetworkInfo): boolean => {
  try {
    BTCAddress.toOutputScript(address, network);
    return true;
  } catch {
    return false;
  }
};
```

`bitcoinjs-lib` v6 does not bundle an elliptic curve implementation. It requires `initEccLib()` before it can build a P2TR output script, and nothing in the repo ever calls it:

```
$ grep -rn "initEccLib" packages/
$
```

So `toOutputScript` throws, the `catch` swallows the error, and the address is reported invalid. Against `bitcoinjs-lib@6.1.7`, the version in the lockfile:

```
taproot   -> No ECC Library provided. You must call initEccLib() with a valid TinySecp256k1Interface instance
p2wpkh    -> OK  0014751e76e8199196d454941c45d1b3a323f1433bd6
p2sh      -> OK  a914b472a266d0bd89c13706a4132ccfb16f7c3b9fcb87
p2pkh     -> OK  76a91477bff20c60e522dfaa3350c39b030a5d004e839a88ac
```

This is a missing initialisation rather than a validation bug: the version of `bitcoinjs-lib` in use supports taproot fine.

## Fix

Register an ECC implementation once, from a small side-effect module imported by the address validation and PSBT paths.

**On the dependency:** `@bitcoinerlab/secp256k1@^1.2.0` is already resolved in `yarn.lock` at exactly that version, pulled in by `ledger-bitcoin` via `@enkryptcom/hw-wallets`:

```
$ yarn why @bitcoinerlab/secp256k1
└─ ledger-bitcoin@npm:0.3.0
   └─ @bitcoinerlab/secp256k1@npm:1.2.0 (via npm:^1.2.0)
```

Adding it as a direct dependency of the extension is a **one line** change to `yarn.lock` and adds no package to the bundle. It is pure JavaScript with a single dependency, `@noble/curves ^1.7.0`, which the lockfile already resolves. I avoided `tiny-secp256k1` because v2 ships a `secp256k1.wasm` binary and browser wasm loaders, which is a real integration cost in the Vite build for identical functionality here.

**Fee sizing.** Registering the curve alone is not enough to make a taproot send succeed. `calculateSizeBasedOnType` sized every output as the account's own payment type, so a P2TR output was charged as 31 vB when it is 43 vB. Fee rates come back from `BTCFeeHandler` as `Math.ceil(sat_per_vbyte)` with an effective floor of 1 sat/vB, so on a 1-in/2-out transaction that 12 vB shortfall drops the real rate to roughly 0.92 sat/vB — under the minimum relay fee, and the broadcast fails. Outputs are now sized from their address type where it is known.

Only bech32/bech32m outputs are classified, since those are the ones whose size differs enough from the account's own type to matter. Anything else keeps the previous behaviour and is at most 3 vB out.

The change output and a partially typed recipient have no entry and are sized as before, so nothing changes for existing send flows. `send-transaction/index.vue` now recomputes the fee when `addressTo` changes, which it previously did not do at all.

This PR deliberately does **not** add `P2TR` to `PaymentType` or derive taproot accounts. It only makes taproot valid as a *recipient*.

## Testing

- `yarn test` in `packages/extension`: 18 passing, up from 11. New cases in `providers/bitcoin/tests/bitcoin.address.validation.test.ts` cover taproot, the other standard address types, malformed and wrong-network addresses, output classification, and the 12 vB size delta.
- Reverting just the `initEccLib` import fails the new taproot case with `expected false to equal true`, so it is a genuine regression test.
- `vue-tsc --build --force` produces exactly the same 309 pre-existing errors as `develop`; none added.
- `eslint` and `prettier --check` clean on the touched files.

**On the test environment.** The new test file carries `// @vitest-environment node`. `bitcoinjs-lib` verifies an ECC library by feeding it `Buffer.from(...)` vectors and `@noble/curves` rejects anything that is not a `Uint8Array`; under the default jsdom environment those two come from different realms, so `instanceof` fails and `initEccLib` throws even though the library is fine.

To confirm that is only a harness artifact and not something users would hit, I built a bundle with the production `nodePolyfills` config from `vite.config.ts` and ran it in a page with no Node `Buffer` present at all:

```
Node Buffer leaked into realm? undefined
--- result ---
Buffer ctor: Buffer2
Buffer instanceof Uint8Array: true
initEccLib: OK
toOutputScript(bc1p): 5120a60869f0dbcf1dc659c9cecbaf8050135ea9e8cdc487053f1dc6880949dc684c
psbt.addOutput(bc1p): OK
```

In a browser there is one realm and the bundled `buffer` polyfill extends that realm's `Uint8Array`, so the check passes.

## Notes

I could not find an existing issue or PR covering this. Happy to adjust the approach, split out the fee sizing, or swap the ECC dependency if you would rather go a different way.

---

Written by Claude Opus 5 with human oversight. Every claim above was checked against the source and the failure modes reproduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Taproot (P2TR) Bitcoin addresses.
  * Bitcoin transaction fees and size estimates now account for each recipient address type.
  * Fees refresh automatically when the recipient address changes.

* **Bug Fixes**
  * Prevented Taproot address processing failures during Bitcoin transactions.
  * Improved validation for Bitcoin addresses across supported address formats and networks.

* **Tests**
  * Added coverage for address validation, output sizing, and Taproot fee calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->